### PR TITLE
centralize the image resources to a single instance - only ever load …

### DIFF
--- a/src/images.py
+++ b/src/images.py
@@ -1,0 +1,76 @@
+import pygame as pg
+from typing import Dict
+from os import path
+import random
+
+PLAYER_IMG = 'manBlue_gun.png'
+BULLET_IMG = 'bullet.png'
+MOB_IMG = 'zombie1_hold.png'
+SPLAT = 'splat green.png'
+MUZZLE_FLASH1 = 'whitePuff15.png'
+MUZZLE_FLASH2 = 'whitePuff16.png'
+MUZZLE_FLASH3 = 'whitePuff17.png'
+MUZZLE_FLASH4 = 'whitePuff18.png'
+LIGHT_MASK = "light_350_soft.png"
+HEALTH_PACK = 'health_pack.png'
+SHOTGUN = 'obj_shotgun.png'
+
+ALL_IMAGES = [PLAYER_IMG, BULLET_IMG, MOB_IMG, SPLAT,
+              MUZZLE_FLASH1, MUZZLE_FLASH2, MUZZLE_FLASH3,
+              MUZZLE_FLASH4, LIGHT_MASK, HEALTH_PACK, SHOTGUN]
+
+IMPACTED_FONT = 'Impacted2.0.ttf'
+ZOMBIE_FONT = 'ZOMBIE.TTF'
+ALL_FONTS = [IMPACTED_FONT, ZOMBIE_FONT]
+
+
+class Images(object):
+    def __init__(self) -> None:
+        self.images: Dict[str, pg.Surface] = {}
+        self.fonts: Dict[str, str] = {}
+
+        # load all the game files
+        game_folder = path.dirname(__file__)
+        img_folder = path.join(game_folder, 'img')
+        for img_name in ALL_IMAGES:
+            img_path = path.join(img_folder, img_name)
+            img = pg.image.load(img_path).convert_alpha()
+            self.images[img_name] = img
+
+        for font_name in ALL_FONTS:
+            font_path = path.join(img_folder, font_name)
+            self.fonts[font_name] = font_path
+
+
+# global image object for loading image objects
+images = None
+
+
+def initialize_images() -> None:
+    global images
+    if not images:
+        images = Images()
+
+
+def get_image(image_name: str) -> pg.Surface:
+    return images.images[image_name]
+
+
+def get_font(font_name: str) -> str:
+    return images.fonts[font_name]
+
+
+def get_muzzle_flash() -> pg.Surface:
+    all_flashes = [MUZZLE_FLASH1, MUZZLE_FLASH2,
+                   MUZZLE_FLASH3, MUZZLE_FLASH4]
+    random_flash = random.choice(all_flashes)
+    return get_image(random_flash)
+
+
+def get_item_image(item_name: str) -> pg.Surface:
+    if item_name == 'health':
+        return get_image(HEALTH_PACK)
+    elif item_name == 'shotgun':
+        return get_image(SHOTGUN)
+
+    assert False, "failure loading image: %s" % item_name

--- a/src/main.py
+++ b/src/main.py
@@ -10,27 +10,33 @@ import tilemap
 import controller as ctrl
 import view
 import sounds
+import images
 
 
 class Game(object):
     def __init__(self) -> None:
 
         pg.mixer.pre_init(44100, -16, 4, 2048)
+
         pg.init()
+
         self.screen = pg.display.set_mode((settings.WIDTH, settings.HEIGHT))
         self.clock = pg.time.Clock()
 
         self.dim_screen = pg.Surface(self.screen.get_size()).convert_alpha()
         self.dim_screen.fill((0, 0, 0, 180))
 
+        # needs to happen after the video mode has been set
+        images.initialize_images()
+
+        # needs to happen after a valid mixer is available
+        sounds.initialize_sounds()
+
         self.all_sprites = LayeredUpdates()
         self._init_groups()
 
         self.controller: ctrl.Controller = ctrl.Controller()
         self.view: view.DungeonView = view.DungeonView(self.screen)
-
-        # needs to happen after a valid mixer is available
-        sounds.initialize_sounds()
 
     def new(self) -> None:
         # initialize all variables and do all the setup for a new game

--- a/src/settings.py
+++ b/src/settings.py
@@ -27,12 +27,10 @@ GRIDHEIGHT = HEIGHT / TILESIZE
 PLAYER_HEALTH = 100
 PLAYER_SPEED = 280
 PLAYER_ROT_SPEED = 200
-PLAYER_IMG = 'manBlue_gun.png'
 PLAYER_HIT_RECT = pygame.Rect(0, 0, 35, 35)
 BARREL_OFFSET = pygame.math.Vector2(30, 10)
 
 # Weapon settings
-BULLET_IMG = 'bullet.png'
 WEAPONS = {}
 WEAPONS['pistol'] = {'bullet_speed': 500,
                      'bullet_lifetime': 1000,
@@ -52,7 +50,6 @@ WEAPONS['shotgun'] = {'bullet_speed': 400,
                       'bullet_count': 12}
 
 # Mob settings
-MOB_IMG = 'zombie1_hold.png'
 MOB_SPEEDS = [150, 100, 75, 125]
 MOB_HIT_RECT = pygame.Rect(0, 0, 30, 30)
 MOB_HEALTH = 100
@@ -62,14 +59,10 @@ AVOID_RADIUS = 50
 DETECT_RADIUS = 400
 
 # Effects
-MUZZLE_FLASHES = ['whitePuff15.png', 'whitePuff16.png', 'whitePuff17.png',
-                  'whitePuff18.png']
-SPLAT = 'splat green.png'
 FLASH_DURATION = 50
 DAMAGE_ALPHA = list(range(0, 255, 55))
 NIGHT_COLOR = (20, 20, 20)
 LIGHT_RADIUS = (500, 500)
-LIGHT_MASK = "light_350_soft.png"
 
 # Layers
 WALL_LAYER = 1
@@ -80,8 +73,6 @@ EFFECTS_LAYER = 4
 ITEMS_LAYER = 1
 
 # Items
-ITEM_IMAGES = {'health': 'health_pack.png',
-               'shotgun': 'obj_shotgun.png'}
 HEALTH_PACK_AMOUNT = 20
 BOB_RANGE = 10
 BOB_SPEED = 0.3

--- a/src/sprites.py
+++ b/src/sprites.py
@@ -1,18 +1,14 @@
 import pygame as pg
 from random import uniform, choice, randint, random
-
 from typing import Any
-
-from os import path
 from pygame.math import Vector2
 from pygame.sprite import Sprite, Group
-
-import settings
-
 from tilemap import collide_hit_rect
 import pytweening as tween
 from itertools import chain
+import settings
 import sounds
+import images
 
 
 def collide_with_walls(sprite: Sprite, group: Group, x_or_y: str) -> None:
@@ -49,16 +45,13 @@ class Humanoid(pg.sprite.Sprite):
     @classmethod
     def _init_base_image(cls, image_file: str) -> None:
         if cls.base_image is None:
-            game_folder = path.dirname(__file__)
-            img_folder = path.join(game_folder, 'img')
-            image_path = path.join(img_folder, image_file)
-            cls.base_image = pg.image.load(image_path).convert_alpha()
+            img = images.get_image(image_file)
+            cls.base_image = img
 
 
 class Player(Humanoid):
     def __init__(self, game: Any, x: int, y: int) -> None:
-
-        super(Player, self).__init__(settings.PLAYER_IMG, x, y)
+        super(Player, self).__init__(images.PLAYER_IMG, x, y)
 
         self._layer = settings.PLAYER_LAYER
         self.groups = game.all_sprites
@@ -146,7 +139,7 @@ class Player(Humanoid):
 class Mob(Humanoid):
     def __init__(self, game: Any, x: int, y: int) -> None:
 
-        super(Mob, self).__init__(settings.MOB_IMG, x, y)
+        super(Mob, self).__init__(images.MOB_IMG, x, y)
 
         self.groups = game.all_sprites, game.mobs
         pg.sprite.Sprite.__init__(self, self.groups)
@@ -164,11 +157,8 @@ class Mob(Humanoid):
         self.speed = choice(settings.MOB_SPEEDS)
         self.target = game.player
 
-        game_folder = path.dirname(__file__)
-        img_folder = path.join(game_folder, 'img')
-        splat_img_path = path.join(img_folder, settings.SPLAT)
-        splat = pg.image.load(splat_img_path).convert_alpha()
-        self.splat = pg.transform.scale(splat, (64, 64))
+        splat_img = images.get_image(images.SPLAT)
+        self.splat = pg.transform.scale(splat_img, (64, 64))
 
     def avoid_mobs(self) -> None:
         for mob in self.game.mobs:
@@ -227,10 +217,7 @@ class Bullet(pg.sprite.Sprite):
         pg.sprite.Sprite.__init__(self, self.groups)
         self.game = game
 
-        game_folder = path.dirname(__file__)
-        img_folder = path.join(game_folder, 'img')
-        blt_img_path = path.join(img_folder, settings.BULLET_IMG)
-        blt_img = pg.image.load(blt_img_path).convert_alpha()
+        blt_img = images.get_image(images.BULLET_IMG)
 
         if weapon == 'pistol':
             self.image = blt_img
@@ -278,11 +265,8 @@ class MuzzleFlash(pg.sprite.Sprite):
         self.game = game
         size = randint(20, 50)
 
-        game_folder = path.dirname(__file__)
-        img_folder = path.join(game_folder, 'img')
-        img_path = path.join(img_folder, choice(settings.MUZZLE_FLASHES))
-        img = pg.image.load(img_path).convert_alpha()
-        self.image = pg.transform.scale(img, (size, size))
+        flash_img = images.get_muzzle_flash()
+        self.image = pg.transform.scale(flash_img, (size, size))
 
         self.rect = self.image.get_rect()
         self.pos = pos
@@ -301,10 +285,7 @@ class Item(pg.sprite.Sprite):
         pg.sprite.Sprite.__init__(self, self.groups)
         self.game = game
 
-        game_folder = path.dirname(__file__)
-        img_folder = path.join(game_folder, 'img')
-        img_path = path.join(img_folder, settings.ITEM_IMAGES[type])
-        self.image = pg.image.load(img_path).convert_alpha()
+        self.image = images.get_item_image(type)
 
         self.rect = self.image.get_rect()
         self.type = type

--- a/src/view.py
+++ b/src/view.py
@@ -1,10 +1,10 @@
-import os
 import pygame as pg
 import settings
 from pygame import Surface
 from pygame.sprite import LayeredUpdates, Group
 from sprites import Mob, Player
 from tilemap import Camera, TiledMap
+import images
 
 
 # HUD functions
@@ -42,19 +42,12 @@ class DungeonView(object):
         self.draw_debug = False
         self.night = False
 
-        # lighting effect
-        game_folder = os.path.dirname(__file__)
-        img_folder = os.path.join(game_folder, 'img')
         self.fog = pg.Surface((settings.WIDTH, settings.HEIGHT))
         self.fog.fill(settings.NIGHT_COLOR)
-        light_img_path = os.path.join(img_folder, settings.LIGHT_MASK)
-        light_mask = pg.image.load(light_img_path).convert_alpha()
-        self.light_mask = light_mask
-        self.light_mask = pg.transform.scale(light_mask, settings.LIGHT_RADIUS)
-        self.light_rect = self.light_mask.get_rect()
 
-        self.hud_font = os.path.join(img_folder, 'Impacted2.0.ttf')
-        self.title_font = os.path.join(img_folder, 'ZOMBIE.TTF')
+        # lighting effect
+        self.light_mask = images.get_image(images.LIGHT_MASK)
+        self.light_rect = self.light_mask.get_rect()
 
     def set_sprites(self, all_sprites: LayeredUpdates) -> None:
         self.all_sprites = all_sprites
@@ -96,11 +89,13 @@ class DungeonView(object):
         remaining_health = player.health / settings.PLAYER_HEALTH
         draw_player_health(self.screen, 10, 10, remaining_health)
         zombies_str = 'Zombies: {}'.format(len(self.mobs))
-        self.draw_text(zombies_str, self.hud_font, 30, settings.WHITE,
+        hud_font = images.get_font(images.IMPACTED_FONT)
+        self.draw_text(zombies_str, hud_font, 30, settings.WHITE,
                        settings.WIDTH - 10, 10, align="topright")
         if paused:
+            title_font = images.get_font(images.ZOMBIE_FONT)
             self.screen.blit(self.dim_screen, (0, 0))
-            self.draw_text("Paused", self.title_font, 105,
+            self.draw_text("Paused", title_font, 105,
                            settings.RED, settings.WIDTH / 2,
                            settings.HEIGHT / 2, align="center")
 
@@ -120,10 +115,11 @@ class DungeonView(object):
 
     def game_over(self) -> None:
         self.screen.fill(settings.BLACK)
-        self.draw_text("GAME OVER", self.title_font, 100, settings.RED,
+        title_font = images.get_font(images.ZOMBIE_FONT)
+        self.draw_text("GAME OVER", title_font, 100, settings.RED,
                        settings.WIDTH / 2, settings.HEIGHT / 2,
                        align="center")
-        self.draw_text("Press a key to start", self.title_font, 75,
+        self.draw_text("Press a key to start", title_font, 75,
                        settings.WHITE, settings.WIDTH / 2,
                        settings.HEIGHT * 3 / 4, align="center")
 


### PR DESCRIPTION
…a given image once and do it on boot.

left with an anti-pattern global variable, similar to the sounds variable but all scopes will want to load images and sounds and this prevents loading them more than once overall a win to reduce loading images/sounds more than necessary