### PR TITLE
DungeonController

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -1,9 +1,29 @@
 from typing import Callable, Dict, List
 import pygame as pg
+from os import path
+import tilemap
+from sprites import Player, Mob, Obstacle, Item, collide_hit_rect
+import view
+from pygame.sprite import spritecollide, groupcollide
+from random import random
+import settings
+import sounds
 
 MOUSE_LEFT = 0
 MOUSE_CENTER = 1
 MOUSE_RIGHT = 2
+
+
+def call_binding(key_id: int,
+                 funcs: Dict[int, Callable[..., None]],
+                 filter_list: List[int]) -> None:
+    key_allowed = True
+    if len(filter_list) > 0:
+        if key_id not in filter_list:
+            key_allowed = False
+
+    if key_allowed:
+        funcs[key_id]()
 
 
 class Controller(object):
@@ -26,22 +46,188 @@ class Controller(object):
     def bind_mouse(self, key: int, binding: Callable[..., None]) -> None:
         self.mouse_bindings[key] = binding
 
-    def update(self) -> None:
+    def handle_input(self, only_handle: List[int] = []) -> None:
+
         keys = pg.key.get_pressed()
         mouse = pg.mouse.get_pressed()
         if any(keys) or any(mouse):
             for key_id in self.bindings:
                 if keys[key_id]:
-                    self.bindings[key_id]()
+                    call_binding(key_id,
+                                 self.bindings,
+                                 only_handle)
 
             for mouse_id in self.mouse_bindings:
                 if mouse[mouse_id]:
-                    self.mouse_bindings[mouse_id]()
+                    call_binding(mouse_id,
+                                 self.mouse_bindings,
+                                 only_handle)
 
             for key_id in self.bindings_down:
+                # only press if key was not down last frame
                 if self.prev_keys[key_id]:
                     continue
                 if keys[key_id]:
-                    self.bindings_down[key_id]()
+                    call_binding(key_id,
+                                 self.bindings_down,
+                                 only_handle)
 
         self.prev_keys = list(keys)
+
+
+class DungeonController(Controller):
+    def __init__(self,
+                 screen: pg.Surface,
+                 map_file: str) -> None:
+        super(DungeonController, self).__init__()
+
+        self.screen = screen
+
+        # initialize all variables and do all the setup for a new game
+        self.all_sprites = pg.sprite.LayeredUpdates()
+        self.walls = pg.sprite.Group()
+        self.mobs = pg.sprite.Group()
+        self.bullets = pg.sprite.Group()
+        self.items = pg.sprite.Group()
+
+        self.clock = pg.time.Clock()
+        self.dt = 0
+
+        self.playing = True
+
+        self.init_map(map_file)
+
+        self.camera = tilemap.Camera(self.map.width, self.map.height)
+
+        self.init_view()
+
+        self.init_controls()
+
+    def init_map(self, map_file: str) -> None:
+
+        game_folder = path.dirname(__file__)
+        map_folder = path.join(game_folder, 'maps')
+
+        # init_map
+        self.map = tilemap.TiledMap(path.join(map_folder, map_file))
+        self.map_img = self.map.make_map()
+        self.map.rect = self.map_img.get_rect()
+        for tile_object in self.map.tmxdata.objects:
+            x = tile_object.x + tile_object.width / 2
+            y = tile_object.y + tile_object.height / 2
+            obj_center = pg.math.Vector2(x, y)
+            if tile_object.name == 'player':
+                pos = pg.math.Vector2(obj_center.x, obj_center.y)
+                self.player = Player(self, pos)
+            if tile_object.name == 'zombie':
+                pos = pg.math.Vector2(obj_center.x, obj_center.y)
+                Mob(self, pos)
+            if tile_object.name == 'wall':
+                pos = pg.math.Vector2(tile_object.x, tile_object.y)
+                Obstacle(self, pos, tile_object.width, tile_object.height)
+            if tile_object.name in ['health', 'shotgun']:
+                Item(self, obj_center, tile_object.name)
+
+    def init_view(self) -> None:
+        # Temporary - eventually this should be one call to construct
+        # a DungeonController that takes only a map and generates all the
+        # sprites from that map
+        self.view = view.DungeonView(self.screen)
+        self.view.set_sprites(self.all_sprites)
+        self.view.set_walls(self.walls)
+        self.view.set_items(self.items)
+        self.view.set_mobs(self.mobs)
+
+    def init_controls(self) -> None:
+
+        self.bind_down(pg.K_n, self.view.toggle_night)
+        self.bind_down(pg.K_h, self.view.toggle_debug)
+
+        # players controls
+        counterclockwise = self.player.turn_counterclockwise
+        self.bind(pg.K_q, counterclockwise)
+
+        clockwise = self.player.turn_clockwise
+        self.bind(pg.K_e, clockwise)
+
+        self.bind(pg.K_LEFT, self.player.move_left)
+        self.bind(pg.K_a, self.player.move_left)
+
+        self.bind(pg.K_RIGHT, self.player.move_right)
+        self.bind(pg.K_d, self.player.move_right)
+
+        self.bind(pg.K_UP, self.player.move_up)
+        self.bind(pg.K_w, self.player.move_up)
+
+        self.bind(pg.K_DOWN, self.player.move_down)
+        self.bind(pg.K_s, self.player.move_down)
+
+        self.bind(pg.K_SPACE, self.player.shoot)
+        self.bind_mouse(MOUSE_LEFT, self.player.shoot)
+
+    def draw(self) -> None:
+        pg.display.set_caption("{:.2f}".format(self.get_fps()))
+
+        self.view.draw(self.player,
+                       self.map,
+                       self.map_img,
+                       self.camera)
+
+        pg.display.flip()
+
+    def update(self) -> None:
+
+        # needs to be called every frame to throttle max framerate
+        self.dt = self.clock.tick(settings.FPS) / 1000.0
+
+        self.handle_input()
+
+        # update portion of the game loop
+        self.all_sprites.update()
+        self.camera.update(self.player)
+
+        # game over?
+        if len(self.mobs) == 0:
+            self.playing = False
+
+        # player hits items
+        hits = spritecollide(self.player, self.items, False)
+        for hit in hits:
+            full_health = self.player.health >= settings.PLAYER_HEALTH
+            if hit.type == 'health' and not full_health:
+                hit.kill()
+                sounds.play(sounds.HEALTH_UP)
+                self.player.add_health(settings.HEALTH_PACK_AMOUNT)
+            if hit.type == 'shotgun':
+                hit.kill()
+                sounds.play(sounds.GUN_PICKUP)
+                self.player.set_weapon('shotgun')
+
+        # mobs hit player
+        hits = spritecollide(self.player, self.mobs, False, collide_hit_rect)
+        for hit in hits:
+            if random() < 0.7:
+                sounds.player_hit_sound()
+                self.player.health -= settings.MOB_DAMAGE
+            hit.vel = pg.math.Vector2(0, 0)
+            if self.player.health <= 0:
+                self.playing = False
+        if hits:
+            self.player.hit()
+            knock_back = pg.math.Vector2(settings.MOB_KNOCKBACK, 0)
+            self.player.pos += knock_back.rotate(-hits[0].rot)
+
+        # bullets hit mobs
+        bullets = self.bullets
+        hits = groupcollide(self.mobs, bullets, False, True)
+        for mob in hits:
+            for bullet in hits[mob]:
+                mob.health -= bullet.damage
+            mob.vel = pg.math.Vector2(0, 0)
+
+    def get_fps(self) -> float:
+        return self.clock.get_fps()
+
+    # the owning object needs to know this
+    def dungeon_over(self) -> bool:
+        return not self.playing

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Union
 import pygame as pg
 from os import path
 import tilemap
@@ -17,10 +17,8 @@ MOUSE_RIGHT = 2
 def call_binding(key_id: int,
                  funcs: Dict[int, Callable[..., None]],
                  filter_list: List[int]) -> None:
-    key_allowed = True
-    if len(filter_list) > 0:
-        if key_id not in filter_list:
-            key_allowed = False
+
+    key_allowed = key_id in filter_list if filter_list else True
 
     if key_allowed:
         funcs[key_id]()
@@ -46,7 +44,7 @@ class Controller(object):
     def bind_mouse(self, key: int, binding: Callable[..., None]) -> None:
         self.mouse_bindings[key] = binding
 
-    def handle_input(self, only_handle: List[int] = []) -> None:
+    def handle_input(self, only_handle: Union[List[int], None] = None) -> None:
 
         keys = pg.key.get_pressed()
         mouse = pg.mouse.get_pressed()

--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,10 @@
 import pygame as pg
-from pygame.sprite import LayeredUpdates, Group, spritecollide, groupcollide
-from pygame.math import Vector2
 import sys
-from random import random
-from os import path
 import settings
-from sprites import Player, Mob, Obstacle, Item, collide_hit_rect
-import tilemap
 import controller as ctrl
-import view
 import sounds
 import images
+import view
 
 
 class Game(object):
@@ -21,7 +15,6 @@ class Game(object):
         pg.init()
 
         self.screen = pg.display.set_mode((settings.WIDTH, settings.HEIGHT))
-        self.clock = pg.time.Clock()
 
         self.dim_screen = pg.Surface(self.screen.get_size()).convert_alpha()
         self.dim_screen.fill((0, 0, 0, 180))
@@ -32,94 +25,26 @@ class Game(object):
         # needs to happen after a valid mixer is available
         sounds.initialize_sounds()
 
-        self.all_sprites = LayeredUpdates()
-        self._init_groups()
+        self.paused = False
 
-        self.controller: ctrl.Controller = ctrl.Controller()
-        self.view: view.DungeonView = view.DungeonView(self.screen)
+        self.new()
 
     def new(self) -> None:
-        # initialize all variables and do all the setup for a new game
-        self.all_sprites = LayeredUpdates()
-        self._init_groups()
-
-        game_folder = path.dirname(__file__)
-        map_folder = path.join(game_folder, 'maps')
-        self.map = tilemap.TiledMap(path.join(map_folder, 'level1.tmx'))
-        self.map_img = self.map.make_map()
-        self.map.rect = self.map_img.get_rect()
-        for tile_object in self.map.tmxdata.objects:
-            obj_center = Vector2(tile_object.x + tile_object.width / 2,
-                                 tile_object.y + tile_object.height / 2)
-            if tile_object.name == 'player':
-                pos = Vector2(obj_center.x, obj_center.y)
-                self.player = Player(self, pos)
-            if tile_object.name == 'zombie':
-                pos = Vector2(obj_center.x, obj_center.y)
-                Mob(self, pos)
-            if tile_object.name == 'wall':
-                pos = Vector2(tile_object.x, tile_object.y)
-                Obstacle(self, pos, tile_object.width, tile_object.height)
-            if tile_object.name in ['health', 'shotgun']:
-                Item(self, obj_center, tile_object.name)
-        self.camera = tilemap.Camera(self.map.width, self.map.height)
-        self.paused = False
         sounds.play(sounds.LEVEL_START)
-
-        # Temporary - eventually this should be one call to construct
-        # a DungeonController that takes only a map and generates all the
-        # sprites from that map
-        self.view = view.DungeonView(self.screen)
-        self.view.set_sprites(self.all_sprites)
-        self.view.set_walls(self.walls)
-        self.view.set_items(self.items)
-        self.view.set_mobs(self.mobs)
-        self.set_default_controls()
-
-    def set_default_controls(self) -> None:
-
-        self.controller.bind(pg.K_ESCAPE, self.quit)
-        self.controller.bind_down(pg.K_n, self.view.toggle_night)
-        self.controller.bind_down(pg.K_h, self.view.toggle_debug)
-        self.controller.bind_down(pg.K_p, self.toggle_paused)
-
-        # players controls
-        counterclockwise = self.player.turn_counterclockwise
-        clockwise = self.player.turn_clockwise
-        self.controller.bind(pg.K_q, counterclockwise)
-        self.controller.bind(pg.K_e, clockwise)
-
-        self.controller.bind(pg.K_LEFT, self.player.move_left)
-        self.controller.bind(pg.K_a, self.player.move_left)
-
-        self.controller.bind(pg.K_RIGHT, self.player.move_right)
-        self.controller.bind(pg.K_d, self.player.move_right)
-
-        self.controller.bind(pg.K_UP, self.player.move_up)
-        self.controller.bind(pg.K_w, self.player.move_up)
-
-        self.controller.bind(pg.K_DOWN, self.player.move_down)
-        self.controller.bind(pg.K_s, self.player.move_down)
-
-        self.controller.bind(pg.K_SPACE, self.player.shoot)
-        self.controller.bind_mouse(ctrl.MOUSE_LEFT, self.player.shoot)
-
-    def _init_groups(self) -> None:
-        self.walls = Group()
-        self.mobs = Group()
-        self.bullets = Group()
-        self.items = Group()
+        self.dungeon = ctrl.DungeonController(self.screen, 'level1.tmx')
+        self.dungeon.bind(pg.K_ESCAPE, self.quit)
+        self.dungeon.bind_down(pg.K_p, self.toggle_paused)
 
     def run(self) -> None:
         # game loop - set self.playing = False to end the game
-        self.playing = True
         pg.mixer.music.play(loops=-1)
-        while self.playing:
-            # fix for Python 2.x
-            self.dt = self.clock.tick(settings.FPS) / 1000.0
+        while not self.dungeon.dungeon_over():
             self.events()
             self.update()
             self.draw()
+
+            if self.paused:
+                self.pause_game()
 
     @staticmethod
     def quit() -> None:
@@ -128,59 +53,12 @@ class Game(object):
 
     def update(self) -> None:
         # always update the controller
-        self.controller.update()
         if self.paused:
-            return
-
-        # update portion of the game loop
-        self.all_sprites.update()
-        self.camera.update(self.player)
-        # game over?
-        if len(self.mobs) == 0:
-            self.playing = False
-        # player hits items
-        hits = spritecollide(self.player, self.items, False)
-        for hit in hits:
-            full_health = self.player.health >= settings.PLAYER_HEALTH
-            if hit.type == 'health' and not full_health:
-                hit.kill()
-                sounds.play(sounds.HEALTH_UP)
-                self.player.add_health(settings.HEALTH_PACK_AMOUNT)
-            if hit.type == 'shotgun':
-                hit.kill()
-                sounds.play(sounds.GUN_PICKUP)
-                self.player.set_weapon('shotgun')
-        # mobs hit player
-        hits = spritecollide(self.player, self.mobs, False, collide_hit_rect)
-        for hit in hits:
-            if random() < 0.7:
-                sounds.player_hit_sound()
-            self.player.health -= settings.MOB_DAMAGE
-            hit.vel = Vector2(0, 0)
-            if self.player.health <= 0:
-                self.playing = False
-        if hits:
-            self.player.hit()
-            knock_back = Vector2(settings.MOB_KNOCKBACK, 0)
-            self.player.pos += knock_back.rotate(-hits[0].rot)
-        # bullets hit mobs
-        hits = groupcollide(self.mobs, self.bullets, False, True)
-        for mob in hits:
-            for bullet in hits[mob]:
-                mob.health -= bullet.damage
-            mob.vel = Vector2(0, 0)
+            print(10)
+        self.dungeon.update()
 
     def draw(self) -> None:
-
-        pg.display.set_caption("{:.2f}".format(self.clock.get_fps()))
-
-        self.view.draw(self.player,
-                       self.map,
-                       self.map_img,
-                       self.camera,
-                       self.paused)
-
-        pg.display.flip()
+        self.dungeon.draw()
 
     def events(self) -> None:
         # catch all events here
@@ -189,10 +67,11 @@ class Game(object):
                 self.quit()
 
     def toggle_paused(self) -> None:
+        print("toggle pause " + str(self.paused))
         self.paused = not self.paused
 
     def show_go_screen(self) -> None:
-        self.view.game_over()
+        self.game_over()
         pg.display.flip()
         self.wait_for_key()
 
@@ -200,7 +79,6 @@ class Game(object):
         pg.event.wait()
         waiting = True
         while waiting:
-            self.clock.tick(settings.FPS)
             for event in pg.event.get():
                 if event.type == pg.QUIT:
                     waiting = False
@@ -208,8 +86,31 @@ class Game(object):
                 if event.type == pg.KEYUP:
                     waiting = False
 
+    def game_over(self) -> None:
+        self.screen.fill(settings.BLACK)
+        title_font = images.get_font(images.ZOMBIE_FONT)
+        view.draw_text(self.screen, "GAME OVER", title_font,
+                       100, settings.RED, settings.WIDTH / 2,
+                       settings.HEIGHT / 2, align="center")
+        view.draw_text(self.screen, "Press a key to start", title_font,
+                       75, settings.WHITE, settings.WIDTH / 2,
+                       settings.HEIGHT * 3 / 4, align="center")
+        pg.display.flip()
 
-# create the game object
+    def pause_game(self) -> None:
+        title_font = images.get_font(images.ZOMBIE_FONT)
+        self.screen.blit(self.dim_screen, (0, 0))
+        view.draw_text(self.screen, "Paused", title_font, 105,
+                       settings.RED, settings.WIDTH / 2,
+                       settings.HEIGHT / 2, align="center")
+
+        pg.display.flip()
+
+        while self.paused:
+            pg.event.wait()
+            self.dungeon.handle_input(only_handle=[pg.K_p])
+
+
 g = Game()
 while True:
     g.new()

--- a/src/view.py
+++ b/src/view.py
@@ -26,6 +26,15 @@ def draw_player_health(surf: Surface, x: int, y: int, pct: float) -> None:
     pg.draw.rect(surf, settings.WHITE, outline_rect, 2)
 
 
+def draw_text(screen: pg.Surface, text: str, font_name: str,
+              size: int, color: tuple, x: int, y: int,
+              align: str = "topleft") -> None:
+    font = pg.font.Font(font_name, size)
+    text_surface = font.render(text, True, color)
+    text_rect = text_surface.get_rect(**{align: (x, y)})
+    screen.blit(text_surface, text_rect)
+
+
 class DungeonView(object):
     def __init__(self, screen: Surface) -> None:
 
@@ -65,8 +74,7 @@ class DungeonView(object):
              player: Player,
              map: TiledMap,
              map_img: Surface,
-             camera: Camera,
-             paused: bool) -> None:
+             camera: Camera) -> None:
 
         self.screen.blit(map_img, camera.apply(map))
 
@@ -90,21 +98,8 @@ class DungeonView(object):
         draw_player_health(self.screen, 10, 10, remaining_health)
         zombies_str = 'Zombies: {}'.format(len(self.mobs))
         hud_font = images.get_font(images.IMPACTED_FONT)
-        self.draw_text(zombies_str, hud_font, 30, settings.WHITE,
-                       settings.WIDTH - 10, 10, align="topright")
-        if paused:
-            title_font = images.get_font(images.ZOMBIE_FONT)
-            self.screen.blit(self.dim_screen, (0, 0))
-            self.draw_text("Paused", title_font, 105,
-                           settings.RED, settings.WIDTH / 2,
-                           settings.HEIGHT / 2, align="center")
-
-    def draw_text(self, text: str, font_name: str, size: int, color: tuple,
-                  x: int, y: int, align: str = "topleft") -> None:
-        font = pg.font.Font(font_name, size)
-        text_surface = font.render(text, True, color)
-        text_rect = text_surface.get_rect(**{align: (x, y)})
-        self.screen.blit(text_surface, text_rect)
+        draw_text(self.screen, zombies_str, hud_font, 30, settings.WHITE,
+                  settings.WIDTH - 10, 10, align="topright")
 
     def render_fog(self, player: Player, camera: Camera) -> None:
         # draw the light mask (gradient) onto fog image
@@ -112,16 +107,6 @@ class DungeonView(object):
         self.light_rect.center = camera.apply(player).center
         self.fog.blit(self.light_mask, self.light_rect)
         self.screen.blit(self.fog, (0, 0), special_flags=pg.BLEND_MULT)
-
-    def game_over(self) -> None:
-        self.screen.fill(settings.BLACK)
-        title_font = images.get_font(images.ZOMBIE_FONT)
-        self.draw_text("GAME OVER", title_font, 100, settings.RED,
-                       settings.WIDTH / 2, settings.HEIGHT / 2,
-                       align="center")
-        self.draw_text("Press a key to start", title_font, 75,
-                       settings.WHITE, settings.WIDTH / 2,
-                       settings.HEIGHT * 3 / 4, align="center")
 
     def toggle_debug(self) -> None:
         self.draw_debug = not self.draw_debug


### PR DESCRIPTION
Move all the dungeon content to a single class. Leave the owning class to handle transitions between dungeons/other contexts.

Details
Extract all code from main.py
Update the mocking method (controller now imports other classes that depend on a fully functioning pygame module - this approach just overrides the functionality we want)