### PR TITLE
Groups for Humanoids

### DIFF
--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -1,6 +1,6 @@
 from humanoid import Player, Mob, collide_hit_rect_with_rect, Humanoid
 from pygame.sprite import spritecollide, groupcollide
-from model import Obstacle, Item, Timer, Groups, GameObject
+from model import Obstacle, Item, Groups, GameObject, Timer
 from item_manager import ItemManager
 from pygame.math import Vector2
 from typing import Dict, List
@@ -71,7 +71,7 @@ class DungeonController(controller.Controller):
 
     def _init_gameobjects(self) -> None:
         GameObject.initialize_gameobjects(self._groups)
-        Humanoid.init_humanoid(self._groups.walls, Timer(self))
+        Humanoid.init_humanoid(Timer(self))
         Player.init_class()
         Mob.init_class(self._map_img, self._groups)
 

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -58,10 +58,10 @@ class DungeonController(controller.Controller):
                                  tile_object.y + tile_object.height / 2)
             if tile_object.name == 'player':
                 pos = Vector2(obj_center.x, obj_center.y)
-                self.player = Player(self._groups, pos)
+                self.player = Player(pos)
             if tile_object.name == 'zombie':
                 pos = Vector2(obj_center.x, obj_center.y)
-                Mob(pos, self._groups, self.player)
+                Mob(pos, self.player)
             if tile_object.name == 'wall':
                 pos = Vector2(tile_object.x, tile_object.y)
                 Obstacle(self._groups.walls, pos, tile_object.width,

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -73,7 +73,7 @@ class DungeonController(controller.Controller):
         GameObject.initialize_gameobjects(self._groups)
         Humanoid.init_humanoid(Timer(self))
         Player.init_class()
-        Mob.init_class(self._map_img, self._groups)
+        Mob.init_class(self._map_img)
 
     def init_controls(self) -> None:
 

--- a/src/humanoid.py
+++ b/src/humanoid.py
@@ -94,7 +94,7 @@ class Humanoid(mdl.GameObject):
 class Player(Humanoid):
     class_initialized = False
 
-    def __init__(self, groups: mdl.Groups, pos: Vector2) -> None:
+    def __init__(self, pos: Vector2) -> None:
 
         if not (self.class_initialized and self.humanoids_initialized):
             raise RuntimeError(
@@ -103,9 +103,8 @@ class Player(Humanoid):
 
         super(Player, self).__init__(settings.PLAYER_HIT_RECT, pos,
                                      settings.PLAYER_HEALTH)
-        pg.sprite.Sprite.__init__(self, groups.all_sprites)
+        pg.sprite.Sprite.__init__(self, self._groups.all_sprites)
 
-        self._groups = groups
         self._weapon = None
         self._damage_alpha = chain(settings.DAMAGE_ALPHA * 4)
         self._rot_speed = 0
@@ -171,8 +170,7 @@ class Mob(Humanoid):
     _splat = None
     _map_img = None
 
-    def __init__(self, pos: Vector2, groups: mdl.Groups,
-                 player: Player) -> None:
+    def __init__(self, pos: Vector2, player: Player) -> None:
 
         if not (self.class_initialized and self.humanoids_initialized):
             raise RuntimeError(
@@ -181,7 +179,8 @@ class Mob(Humanoid):
 
         super(Mob, self).__init__(settings.MOB_HIT_RECT, pos,
                                   settings.MOB_HEALTH)
-        pg.sprite.Sprite.__init__(self, [groups.all_sprites, groups.mobs])
+        my_groups = [self._groups.all_sprites, self._groups.mobs]
+        pg.sprite.Sprite.__init__(self, my_groups)
 
         self.speed = choice(settings.MOB_SPEEDS)
         self.target = player

--- a/src/humanoid.py
+++ b/src/humanoid.py
@@ -16,7 +16,6 @@ import pygame as pg
 class Humanoid(mdl.GameObject):
     """GameObject with health and motion. We will add more to this later."""
     humanoids_initialized = False
-    _walls: Union[None, Group] = None
     _timer: Union[None, mdl.Timer] = None
 
     def __init__(self, hit_rect: pg.Rect, pos: Vector2,
@@ -31,6 +30,10 @@ class Humanoid(mdl.GameObject):
 
         self.backpack: List[mdl.Item] = []
         self.backpack_size = 8
+
+    @property
+    def _walls(self) -> Group:
+        return self._groups.walls
 
     @property
     def health(self) -> int:
@@ -82,9 +85,8 @@ class Humanoid(mdl.GameObject):
         return len(self.backpack) >= self.backpack_size
 
     @classmethod
-    def init_humanoid(cls, walls: mdl.Group, timer: mdl.Timer) -> None:
+    def init_humanoid(cls, timer: mdl.Timer) -> None:
         if not cls.humanoids_initialized:
-            cls._walls = walls
             cls._timer = timer
             cls.humanoids_initialized = True
 
@@ -168,7 +170,6 @@ class Mob(Humanoid):
     class_initialized = False
     _splat = None
     _map_img = None
-    _mob_group = None
 
     def __init__(self, pos: Vector2, groups: mdl.Groups,
                  player: Player) -> None:
@@ -185,6 +186,10 @@ class Mob(Humanoid):
         self.speed = choice(settings.MOB_SPEEDS)
         self.target = player
 
+    @property
+    def _mob_group(self) -> Group:
+        return self._groups.mobs
+
     @classmethod
     def init_class(cls, map_img: pg.Surface, groups: mdl.Groups) -> None:
         if not cls.class_initialized:
@@ -192,7 +197,6 @@ class Mob(Humanoid):
             splat_img = images.get_image(images.SPLAT)
             cls._splat = pg.transform.scale(splat_img, (64, 64))
             cls._map_img = map_img
-            cls._mob_group = groups.mobs
             cls.class_initialized = True
 
     def _avoid_mobs(self) -> None:

--- a/src/humanoid.py
+++ b/src/humanoid.py
@@ -190,7 +190,7 @@ class Mob(Humanoid):
         return self._groups.mobs
 
     @classmethod
-    def init_class(cls, map_img: pg.Surface, groups: mdl.Groups) -> None:
+    def init_class(cls, map_img: pg.Surface) -> None:
         if not cls.class_initialized:
             cls._init_base_image(images.MOB_IMG)
             splat_img = images.get_image(images.SPLAT)

--- a/src/test/pygame_mock.py
+++ b/src/test/pygame_mock.py
@@ -52,4 +52,4 @@ def initialize_gameobjects(groups: model.Groups, timer: model.Timer) -> None:
     hmn.Humanoid.init_humanoid(timer)
     hmn.Player.init_class()
     blank_screen = pygame.Surface((800, 600))
-    hmn.Mob.init_class(blank_screen, groups)
+    hmn.Mob.init_class(blank_screen)

--- a/src/test/pygame_mock.py
+++ b/src/test/pygame_mock.py
@@ -49,7 +49,7 @@ def initialize_pygame() -> None:
 
 def initialize_gameobjects(groups: model.Groups, timer: model.Timer) -> None:
     model.GameObject.initialize_gameobjects(groups)
-    hmn.Humanoid.init_humanoid(groups.walls, timer)
+    hmn.Humanoid.init_humanoid(timer)
     hmn.Player.init_class()
     blank_screen = pygame.Surface((800, 600))
     hmn.Mob.init_class(blank_screen, groups)

--- a/src/test/test_humanoid.py
+++ b/src/test/test_humanoid.py
@@ -1,18 +1,14 @@
 import unittest
 from typing import Union
-import sys, os
+import os
 
 from pygame.math import Vector2
 
-sys.path.append('../../')
-sys.path.append('../')
-sys.path.append('.')
 import pygame
 from pygame.sprite import Group, LayeredUpdates
 import model
 import humanoid as hmn
-import images
-import sounds
+
 from src.test.pygame_mock import MockTimer, Pygame, initialize_pygame, \
     initialize_gameobjects
 from weapon import Weapon, Bullet, MuzzleFlash

--- a/src/test/test_humanoid.py
+++ b/src/test/test_humanoid.py
@@ -37,7 +37,7 @@ def _make_player() -> hmn.Player:
     groups = Connection.groups
     pos = pygame.math.Vector2(0, 0)
 
-    player = hmn.Player(groups, pos)
+    player = hmn.Player(pos)
     player.set_weapon('pistol')
     return player
 
@@ -47,7 +47,7 @@ def _make_mob(player: hmn.Player,
     groups = Connection.groups
     if pos is None:
         pos = pygame.math.Vector2(0, 0)
-    return hmn.Mob(groups, pos, player)
+    return hmn.Mob(groups, player)
 
 
 def setUpModule() -> None:

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -30,7 +30,7 @@ def setUpModule() -> None:
 def _make_player() -> hmn.Player:
     groups = Connection.groups
     pos = pygame.math.Vector2(0, 0)
-    player = hmn.Player(groups, pos)
+    player = hmn.Player(pos)
     player.set_weapon('pistol')
     return player
 


### PR DESCRIPTION
Since Humanoid objects subclass GameObjects, which now have the groups class variable, it is no longer necessary to define _walls or _mob_group class variables for Player or Mobs. Accordingly, we no longer need to pass groups to instantiate a Player or Mob.