### PR TITLE
Separate Item and Mod responsibilities

### DIFF
--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -63,7 +63,7 @@ class DungeonController(controller.Controller):
             if tile_object.name == 'wall':
                 pos = Vector2(tile_object.x, tile_object.y)
                 Obstacle(pos, tile_object.width, tile_object.height)
-            if tile_object.name in ['pistol', 'healthpack']:  # 'healthpack', 'shotgun',
+            if tile_object.name in ['pistol', 'healthpack', 'shotgun']:
                 ItemManager.item(obj_center, tile_object.name)
 
     def _init_gameobjects(self) -> None:

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -37,10 +37,7 @@ class DungeonController(controller.Controller):
         self._camera = tilemap.Camera(self._map.width, self._map.height)
 
         self._view = view.DungeonView(screen)
-        self._view.set_sprites(self._groups.all_sprites)
-        self._view.set_walls(self._groups.walls)
-        self._view.set_items(self._groups.items)
-        self._view.set_mobs(self._groups.mobs)
+        self._view.set_groups(self._groups)
 
         self.init_controls()
 

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -130,8 +130,8 @@ class DungeonController(controller.Controller):
             self._playing = False
 
         # player hits items
-        items: List[ItemObject] = spritecollide(self.player, self._groups.items,
-                                                False)
+        items: List[ItemObject] = spritecollide(self.player,
+                                                self._groups.items, False)
         for item in items:
             if not self.player.backpack_full:
                 self.player.gain_item(item)
@@ -193,8 +193,8 @@ class DungeonController(controller.Controller):
         used_item = False
         try:
             itm = self.player.backpack[idx]
-            if isinstance(itm, Item):
-                used_item = itm.use(self.player)
+            itm.use(self.player)
+
         except Exception as e:
             print(e)
 

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -68,7 +68,7 @@ class DungeonController(controller.Controller):
             if tile_object.name == 'wall':
                 pos = Vector2(tile_object.x, tile_object.y)
                 Obstacle(pos, tile_object.width, tile_object.height)
-            if tile_object.name in ['health', 'shotgun', 'pistol']:
+            if tile_object.name in ['healthpack', 'shotgun', 'pistol']:
                 ItemManager.item(obj_center, tile_object.name)
 
     def _init_gameobjects(self) -> None:

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -192,8 +192,6 @@ class DungeonController(controller.Controller):
                 self.player.equip(item_mod)
             else:
                 item_mod.use()
-
-
         except Exception as e:
             print(e)
 

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -57,11 +57,9 @@ class DungeonController(controller.Controller):
             obj_center = Vector2(tile_object.x + tile_object.width / 2,
                                  tile_object.y + tile_object.height / 2)
             if tile_object.name == 'player':
-                pos = Vector2(obj_center.x, obj_center.y)
-                self.player = Player(pos)
+                self.player = Player(obj_center)
             if tile_object.name == 'zombie':
-                pos = Vector2(obj_center.x, obj_center.y)
-                Mob(pos, self.player)
+                Mob(obj_center, self.player)
             if tile_object.name == 'wall':
                 pos = Vector2(tile_object.x, tile_object.y)
                 Obstacle(pos, tile_object.width, tile_object.height)
@@ -189,8 +187,12 @@ class DungeonController(controller.Controller):
 
         used_item = False
         try:
-            itm = self.player.backpack[idx]
-            itm.use(self.player)
+            item_mod = self.player.backpack[idx]
+            if item_mod.equipable:
+                self.player.equip(item_mod)
+            else:
+                item_mod.use()
+
 
         except Exception as e:
             print(e)

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -1,6 +1,8 @@
 from humanoid import Player, Mob
 from pygame.sprite import spritecollide, groupcollide
-from model import Obstacle, Item, Groups, GameObject, Timer, \
+
+from mod import ItemObject
+from model import Obstacle, Groups, GameObject, Timer, \
     collide_hit_rect_with_rect, DynamicObject
 from item_manager import ItemManager
 from pygame.math import Vector2
@@ -67,7 +69,7 @@ class DungeonController(controller.Controller):
                 pos = Vector2(tile_object.x, tile_object.y)
                 Obstacle(pos, tile_object.width, tile_object.height)
             if tile_object.name in ['health', 'shotgun', 'pistol']:
-                ItemManager.item(self._groups, obj_center, tile_object.name)
+                ItemManager.item(obj_center, tile_object.name)
 
     def _init_gameobjects(self) -> None:
         GameObject.initialize_gameobjects(self._groups)
@@ -128,11 +130,11 @@ class DungeonController(controller.Controller):
             self._playing = False
 
         # player hits items
-        items: List[Item] = spritecollide(self.player, self._groups.items,
-                                          False)
+        items: List[ItemObject] = spritecollide(self.player, self._groups.items,
+                                                False)
         for item in items:
-            if not self.player.backpack_full():
-                self.player.add_item_to_backpack(item)
+            if not self.player.backpack_full:
+                self.player.gain_item(item)
                 item.kill()
 
         # mobs hit player

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -63,7 +63,7 @@ class DungeonController(controller.Controller):
             if tile_object.name == 'wall':
                 pos = Vector2(tile_object.x, tile_object.y)
                 Obstacle(pos, tile_object.width, tile_object.height)
-            if tile_object.name in ['healthpack', 'shotgun', 'pistol']:
+            if tile_object.name in ['pistol', 'healthpack']:  # 'healthpack', 'shotgun',
                 ItemManager.item(obj_center, tile_object.name)
 
     def _init_gameobjects(self) -> None:
@@ -191,7 +191,8 @@ class DungeonController(controller.Controller):
             if item_mod.equipable:
                 self.player.equip(item_mod)
             else:
-                item_mod.use()
+                assert item_mod.expendable
+                self.player.expend(item_mod)
         except Exception as e:
             print(e)
 

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -131,9 +131,7 @@ class DungeonController(controller.Controller):
         items: List[ItemObject] = spritecollide(self.player,
                                                 self._groups.items, False)
         for item in items:
-            if not self.player.backpack_full:
-                self.player.gain_item(item)
-                item.kill()
+            self.player.attempt_pickup(item)
 
         # mobs hit player
         mobs: List[Mob] = spritecollide(self.player, self._groups.mobs, False,

--- a/src/hud.py
+++ b/src/hud.py
@@ -41,9 +41,7 @@ class HUD(object):
         rects: Dict[mod.ModLocation, pg.Rect] = {}
 
         i = 0
-        for loc in mod.ModLocation:
-            if loc == mod.ModLocation.BACKPACK:
-                continue
+        for loc in mod.EQUIP_LOCATIONS:
             x_i = x + i * (mod_size + 3)
             fill_rect = pg.Rect(x_i + 3, y + 3, mod_size, mod_size)
             rects[loc] = fill_rect

--- a/src/hud.py
+++ b/src/hud.py
@@ -30,9 +30,7 @@ class HUD(object):
 
         # generate rects for mods/backpack
         self.mod_rects = self.generate_mod_rects()
-        backpack_rects, img_rects = self.generate_backpack_rects()
-        self.backpack_rects = backpack_rects
-        self.backpack_img_rects = img_rects
+        self.backpack_rects = self.generate_backpack_rects()
 
         self.selected_mod = NO_SELECTION
         self.selected_item = NO_SELECTION
@@ -44,6 +42,8 @@ class HUD(object):
 
         i = 0
         for loc in mod.ModLocation:
+            if loc == mod.ModLocation.BACKPACK:
+                continue
             x_i = x + i * (mod_size + 3)
             fill_rect = pg.Rect(x_i + 3, y + 3, mod_size, mod_size)
             rects[loc] = fill_rect
@@ -51,22 +51,19 @@ class HUD(object):
 
         return rects
 
-    def generate_backpack_rects(self) -> List[List[pg.Rect]]:
+    def generate_backpack_rects(self) -> List[pg.Rect]:
         item_size = 50
         x, y = self._hud_pos
         x += self._bar_length + 3
         y += 4
         rects: List[pg.Rect] = []
-        img_rects: List[pg.Rect] = []
         for i in range(4):
             for j in range(2):
                 x_i = x + i * (item_size + 2)
                 y_i = y + j * (item_size + 2)
                 fill_rect = pg.Rect(x_i, y_i, item_size, item_size)
-                img_rect = pg.Rect(x_i + 5, y_i + 15, item_size, item_size)
                 rects.append(fill_rect)
-                img_rects.append(img_rect)
-        return [rects, img_rects]
+        return rects
 
     def draw(self, player: Player) -> None:
         self.draw_hud_base()
@@ -118,7 +115,7 @@ class HUD(object):
 
         for idx, loc in enumerate(player.active_mods):
             mod = player.active_mods[loc]
-            img = mod.mod_image
+            img = mod.image
 
             img = pg.transform.scale(img, (70, 70))
 
@@ -130,12 +127,13 @@ class HUD(object):
                       20, settings.WHITE, r.x + 10, r.y + 10, align="center")
 
     def draw_backpack(self, player: Player) -> None:
-        for idx, r in enumerate(self.backpack_rects):
-            col = settings.HUDDARK
+        for idx, rect in enumerate(self.backpack_rects):
+            color = settings.HUDDARK
             if self.selected_item == idx:
-                col = settings.RED
-            pg.draw.rect(self._screen, col, r, 2)
+                color = settings.RED
+            pg.draw.rect(self._screen, color, rect, 2)
 
-        for idx, item in enumerate(player.backpack):
-            r = self.backpack_img_rects[idx]
-            self._screen.blit(item.image, r)
+        for idx, item_mod in enumerate(player.backpack):
+            rect = self.backpack_rects[idx]
+            img = pg.transform.scale(item_mod.image, (rect.width, rect.height))
+            self._screen.blit(img, rect)

--- a/src/humanoid.py
+++ b/src/humanoid.py
@@ -73,15 +73,16 @@ class Humanoid(mdl.DynamicObject):
     def stop_y(self) -> None:
         self._vel.y = 0
 
-    def add_item_to_backpack(self, item: mdl.Item) -> None:
+    def gain_item(self, item: mod.ItemObject) -> None:
 
-        if isinstance(item, mod.Mod):
-            if item.loc not in self.active_mods:
-                item.use(self)
-                return
+        if item.mod.equipable and item.mod.loc not in self.active_mods:
+            self.active_mods[item.mod.loc] = item.mod
+            item.kill()
+        elif not self.backpack_full:
+            self.backpack.append(item.mod)
+            item.kill()
 
-        self.backpack.append(item)
-
+    @property
     def backpack_full(self) -> bool:
         return len(self.backpack) >= self.backpack_size
 

--- a/src/humanoid.py
+++ b/src/humanoid.py
@@ -83,7 +83,7 @@ class Humanoid(mdl.DynamicObject):
         item_mod.use(self)
 
     def expend(self, item_mod: mod.Mod) -> None:
-        assert item_mod.mod.expendable
+        assert item_mod.expendable
         assert item_mod in self.backpack
         item_mod.use(self)
         if item_mod.expended:

--- a/src/humanoid.py
+++ b/src/humanoid.py
@@ -73,10 +73,31 @@ class Humanoid(mdl.DynamicObject):
     def stop_y(self) -> None:
         self._vel.y = 0
 
+    def equip(self, item_mod: mod.Mod) -> None:
+        assert item_mod.equipable
+
+        self._move_mod_at_loc_to_backpack(item_mod.loc)
+        if item_mod in self.backpack:
+            self.backpack.remove(item_mod)
+        self.active_mods[item_mod.loc] = item_mod
+        item_mod.use(self)
+
+    def expend(self, item_mod: mod.Mod) -> None:
+        assert item_mod.mod.expendable
+        assert item_mod in self.backpack
+        item_mod.use(self)
+        if item_mod.expended:
+            self.backpack.remove(item_mod)
+
+    def _move_mod_at_loc_to_backpack(self, loc: mod.ModLocation) -> None:
+        old_mod = self.active_mods.pop(loc, None)
+        if old_mod is not None:
+            self.backpack.append(old_mod)
+
     def gain_item(self, item: mod.ItemObject) -> None:
 
         if item.mod.equipable and item.mod.loc not in self.active_mods:
-            self.active_mods[item.mod.loc] = item.mod
+            self.equip(item.mod)
             item.kill()
         elif not self.backpack_full:
             self.backpack.append(item.mod)

--- a/src/humanoid.py
+++ b/src/humanoid.py
@@ -94,7 +94,7 @@ class Humanoid(mdl.DynamicObject):
         if old_mod is not None:
             self.backpack.append(old_mod)
 
-    def gain_item(self, item: mod.ItemObject) -> None:
+    def attempt_pickup(self, item: mod.ItemObject) -> None:
 
         if item.mod.equipable and item.mod.loc not in self.active_mods:
             self.equip(item.mod)

--- a/src/item_manager.py
+++ b/src/item_manager.py
@@ -1,22 +1,17 @@
 import settings
 import pygame as pg
-from model import Groups, Item
-from mod import ShotgunMod, HealthPack, PistolObject
+from mod import HealthPackObject, PistolObject, ShotgunObject, ItemObject
 
-item_contructors = {settings.HEALTHPACK_ITEM: HealthPack,
-                    settings.SHOTGUN_MOD: ShotgunMod,
-                    settings.PISTOL_MOD: PistolObject}
+item_contructors = {settings.HEALTHPACK: HealthPackObject,
+                    settings.SHOTGUN: ShotgunObject,
+                    settings.PISTOL: PistolObject}
 
 
 class ItemManager(object):
     @staticmethod
-    def item(groups: Groups, pos: pg.math.Vector2,
-             label: str) -> Item:
+    def item(pos: pg.math.Vector2, label: str) -> ItemObject:
         if label not in item_contructors:
             error_msg = 'Item label %s not recognized.'
             raise ValueError(error_msg % (label,))
 
-        ctr = item_contructors[label]
-        if label == settings.PISTOL_MOD:
-            return ctr(pos)
-        return ctr(groups, pos)
+        return item_contructors[label](pos)

--- a/src/item_manager.py
+++ b/src/item_manager.py
@@ -17,4 +17,4 @@ class ItemManager(object):
             raise ValueError(error_msg % (label,))
 
         ctr = item_contructors[label]
-        return ctr(groups, pos, label)
+        return ctr(groups, pos)

--- a/src/item_manager.py
+++ b/src/item_manager.py
@@ -1,11 +1,11 @@
 import settings
 import pygame as pg
 from model import Groups, Item
-from mod import ShotgunMod, PistolMod, HealthPack
+from mod import ShotgunMod, HealthPack, PistolObject
 
 item_contructors = {settings.HEALTHPACK_ITEM: HealthPack,
                     settings.SHOTGUN_MOD: ShotgunMod,
-                    settings.PISTOL_MOD: PistolMod}
+                    settings.PISTOL_MOD: PistolObject}
 
 
 class ItemManager(object):
@@ -17,4 +17,6 @@ class ItemManager(object):
             raise ValueError(error_msg % (label,))
 
         ctr = item_contructors[label]
+        if label == settings.PISTOL_MOD:
+            return ctr(pos)
         return ctr(groups, pos)

--- a/src/item_manager.py
+++ b/src/item_manager.py
@@ -1,8 +1,7 @@
 import settings
 import pygame as pg
-from model import Groups, Item, HealthPack
-from mod import ShotgunMod, PistolMod
-
+from model import Groups, Item
+from mod import ShotgunMod, PistolMod, HealthPack
 
 item_contructors = {settings.HEALTHPACK_ITEM: HealthPack,
                     settings.SHOTGUN_MOD: ShotgunMod,

--- a/src/maps/level1.tmx
+++ b/src/maps/level1.tmx
@@ -190,9 +190,9 @@
   <object id="92" name="zombie" x="1504" y="736" width="32" height="32"/>
   <object id="93" name="zombie" x="1856" y="752" width="32" height="32"/>
   <object id="94" name="zombie" x="1872" y="576" width="32" height="32"/>
-  <object id="99" name="health" x="848" y="912" width="32" height="32"/>
+  <object id="99" name="healthpack" x="848" y="912" width="32" height="32"/>
   <object id="100" name="shotgun" x="976" y="528" width="32" height="32"/>
-  <object id="132" name="health" x="3024" y="592" width="32" height="32"/>
+  <object id="132" name="healthpack" x="3024" y="592" width="32" height="32"/>
   <object id="133" name="zombie" x="2800" y="1168" width="32" height="32"/>
   <object id="134" name="zombie" x="2704" y="1104" width="32" height="32"/>
   <object id="135" name="zombie" x="2832" y="1104" width="32" height="32"/>

--- a/src/mod.py
+++ b/src/mod.py
@@ -33,28 +33,20 @@ class Mod(object):
         self.image = image
         self.label = label
 
-    # TODO (dvirk): Split this logic to two different functions.
-    def use(self, player: Any) -> None:
-        """Either expend the item or move it to its equipped location."""
-        assert self in player.backpack
-        # Remove from backpack
-        player.backpack.remove(self)
-
-        if self.equipable:
-            self._move_mod_at_loc_to_backpack(player)
-            player.active_mods[self.loc] = self
-
-    def _move_mod_at_loc_to_backpack(self, player: Any) -> None:
-        old_mod = player.active_mods.pop(self.loc, None)
-        if old_mod is not None:
-            player.backpack.append(old_mod)
-
     @property
     def equipable(self) -> bool:
         return self.loc != ModLocation.BACKPACK
 
     @property
+    def expendable(self) -> bool:
+        return not self.equipable
+
+    @property
     def expended(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    def use(self, player: Any) -> None:
         raise NotImplementedError
 
 
@@ -66,7 +58,7 @@ class WeaponMod(Mod):
                                         label=label)
 
     def use(self, player: Any) -> None:
-        super(WeaponMod, self).use(player)
+        print('Setting weapon to %s' % self.label)
         player.set_weapon(self.label)
 
     @property
@@ -108,7 +100,7 @@ class HealthPackMod(Mod):
             self._expended = True
 
     @property
-    def expended(self) -> bool:
+    def expended(self):
         return self._expended
 
 

--- a/src/mod.py
+++ b/src/mod.py
@@ -56,6 +56,7 @@ class WeaponMod(Mod):
         super(WeaponMod, self).__init__(sid=sid, loc=loc, image=image,
                                         label=label)
 
+    # TODO(dkafri): Thus functionality should be handled by the Backpack.
     def use(self, player: Any) -> None:
         player.set_weapon(self.label)
 
@@ -94,7 +95,6 @@ class HealthPackMod(Mod):
         if player.damaged:
             sounds.play(sounds.HEALTH_UP)
             player.increment_health(settings.HEALTH_PACK_AMOUNT)
-            player.backpack.remove(self)
             self._expended = True
 
     @property

--- a/src/mod.py
+++ b/src/mod.py
@@ -54,11 +54,11 @@ class Mod(model.Item):
 
 
 class ShotgunMod(Mod):
-    def __init__(self, groups: model.Groups, pos: pg.math.Vector2,
-                 label: str) -> None:
+    def __init__(self, groups: model.Groups, pos: pg.math.Vector2) -> None:
         sid = ModID.SHOTGUN
         loc = ModLocation.ARMS
         img = images.get_image(images.SHOTGUN_MOD)
+        label = settings.SHOTGUN_MOD
         super(ShotgunMod, self).__init__(sid=sid,
                                          loc=loc,
                                          image=img,
@@ -68,11 +68,11 @@ class ShotgunMod(Mod):
 
 
 class PistolMod(Mod):
-    def __init__(self, groups: model.Groups, pos: pg.math.Vector2,
-                 label: str) -> None:
+    def __init__(self, groups: model.Groups, pos: pg.math.Vector2) -> None:
         sid = ModID.PISTOL
         loc = ModLocation.ARMS
         img = images.get_image(images.PISTOL_MOD)
+        label = settings.PISTOL_MOD
         super(PistolMod, self).__init__(sid=sid,
                                         loc=loc,
                                         image=img,
@@ -82,8 +82,8 @@ class PistolMod(Mod):
 
 
 class HealthPack(Item):
-    def __init__(self, groups: Groups, pos: pg.math.Vector2,
-                 label: str) -> None:
+    def __init__(self, groups: Groups, pos: pg.math.Vector2) -> None:
+        label = settings.HEALTHPACK_ITEM
         super(HealthPack, self).__init__(groups, pos, label)
 
     def use(self, player: Any) -> bool:

--- a/src/mod.py
+++ b/src/mod.py
@@ -45,7 +45,6 @@ class Mod(object):
     def expended(self) -> bool:
         raise NotImplementedError
 
-    @property
     def use(self, player: Any) -> None:
         raise NotImplementedError
 
@@ -58,7 +57,6 @@ class WeaponMod(Mod):
                                         label=label)
 
     def use(self, player: Any) -> None:
-        print('Setting weapon to %s' % self.label)
         player.set_weapon(self.label)
 
     @property
@@ -100,7 +98,7 @@ class HealthPackMod(Mod):
             self._expended = True
 
     @property
-    def expended(self):
+    def expended(self) -> bool:
         return self._expended
 
 

--- a/src/mod.py
+++ b/src/mod.py
@@ -3,6 +3,9 @@ import pygame as pg
 import images
 from typing import Any
 import model
+import settings
+import sounds
+from model import Item, Groups
 
 
 class ModID(Enum):
@@ -32,6 +35,7 @@ class Mod(model.Item):
         self.mod_image = image
 
     '''this will equip that mod at the proper location'''
+
     def use(self, player: Any) -> bool:
         old_mod = None
         if self.loc in player.active_mods:
@@ -75,3 +79,18 @@ class PistolMod(Mod):
                                         groups=groups,
                                         pos=pos,
                                         label=label)
+
+
+class HealthPack(Item):
+    def __init__(self, groups: Groups, pos: pg.math.Vector2,
+                 label: str) -> None:
+        super(HealthPack, self).__init__(groups, pos, label)
+
+    def use(self, player: Any) -> bool:
+        if player.health < settings.PLAYER_HEALTH:
+            sounds.play(sounds.HEALTH_UP)
+            player.increment_health(settings.HEALTH_PACK_AMOUNT)
+            player.backpack.remove(self)
+            self.kill()
+            return True
+        return False

--- a/src/mod.py
+++ b/src/mod.py
@@ -144,7 +144,6 @@ class PistolObject(ItemObject):
         self._check_class_initialized()
         mod = PistolMod()
 
-        # TODO(dkafri): image should not need to be passed to the super.init?
         if self.base_image is None:
             self._init_base_image(images.PISTOL)
 
@@ -156,7 +155,6 @@ class ShotgunObject(ItemObject):
         self._check_class_initialized()
         mod = ShotgunMod()
 
-        # TODO(dkafri): image should not need to be passed to the super.init?
         if self.base_image is None:
             self._init_base_image(images.SHOTGUN)
 
@@ -168,7 +166,6 @@ class HealthPackObject(ItemObject):
         self._check_class_initialized()
         mod = HealthPackMod()
 
-        # TODO(dkafri): image should not need to be passed to the super.init?
         if self.base_image is None:
             self._init_base_image(images.HEALTH_PACK)
 

--- a/src/mod.py
+++ b/src/mod.py
@@ -146,7 +146,7 @@ class PistolObject(ItemObject):
 
         # TODO(dkafri): image should not need to be passed to the super.init?
         if self.base_image is None:
-            self._init_base_image(images.PISTOL_MOD)
+            self._init_base_image(images.PISTOL)
 
         super(PistolObject, self).__init__(mod, self.base_image, pos)
 
@@ -158,7 +158,7 @@ class ShotgunObject(ItemObject):
 
         # TODO(dkafri): image should not need to be passed to the super.init?
         if self.base_image is None:
-            self._init_base_image(images.SHOTGUN_MOD)
+            self._init_base_image(images.SHOTGUN)
 
         super(ShotgunObject, self).__init__(mod, self.base_image, pos)
 

--- a/src/mod.py
+++ b/src/mod.py
@@ -4,7 +4,7 @@ import pytweening as tween
 from pygame.math import Vector2
 
 import images
-from typing import Any, Union
+from typing import Any
 import settings
 import sounds
 from model import DynamicObject
@@ -44,7 +44,7 @@ class Mod(object):
             self._move_mod_at_loc_to_backpack(player)
             player.active_mods[self.loc] = self
 
-    def _move_mod_at_loc_to_backpack(self, player):
+    def _move_mod_at_loc_to_backpack(self, player: Any) -> None:
         old_mod = player.active_mods.pop(self.loc, None)
         if old_mod is not None:
             player.backpack.append(old_mod)
@@ -107,7 +107,7 @@ class WeaponMod(Mod):
         player.set_weapon(self.label)
 
     @property
-    def expended(self):
+    def expended(self) -> bool:
         return False
 
 

--- a/src/mod.py
+++ b/src/mod.py
@@ -58,43 +58,6 @@ class Mod(object):
         raise NotImplementedError
 
 
-class ItemObject(DynamicObject):
-    """A bobbing in-game object that can be picked up."""
-
-    def __init__(self, mod: Mod, image: pg.Surface, pos: Vector2) -> None:
-        self._check_class_initialized()
-        super(ItemObject, self).__init__(image.get_rect(), pos)
-
-        my_groups = [self._groups.all_sprites, self._groups.items]
-        pg.sprite.Sprite.__init__(self, my_groups)
-
-        self.image = image
-        self._mod = mod
-        self._tween = tween.easeInOutSine
-        self._step = 0
-        self._bob_direction = 1
-        self._bob_period = settings.BOB_RANGE
-        self._bob_speed = settings.BOB_SPEED
-
-    @property
-    def mod(self) -> Mod:
-        return self._mod
-
-    def update(self) -> None:
-        # bobbing motion
-        offset = self._bob_offset()
-        self.rect.centery = self.pos.y + offset * self._bob_direction
-        self._step += self._bob_speed
-        if self._step > self._bob_period:
-            self._step = 0
-            self._bob_direction *= -1
-
-    def _bob_offset(self) -> float:
-        offset = self._bob_period * (
-            self._tween(self._step / self._bob_period) - 0.5)
-        return offset
-
-
 class WeaponMod(Mod):
     def __init__(self, sid: ModID, image: pg.Surface,
                  label: str) -> None:
@@ -147,6 +110,43 @@ class HealthPackMod(Mod):
     @property
     def expended(self) -> bool:
         return self._expended
+
+
+class ItemObject(DynamicObject):
+    """A bobbing in-game object that can be picked up."""
+
+    def __init__(self, mod: Mod, image: pg.Surface, pos: Vector2) -> None:
+        self._check_class_initialized()
+        super(ItemObject, self).__init__(image.get_rect(), pos)
+
+        my_groups = [self._groups.all_sprites, self._groups.items]
+        pg.sprite.Sprite.__init__(self, my_groups)
+
+        self.image = image
+        self._mod = mod
+        self._tween = tween.easeInOutSine
+        self._step = 0
+        self._bob_direction = 1
+        self._bob_period = settings.BOB_RANGE
+        self._bob_speed = settings.BOB_SPEED
+
+    @property
+    def mod(self) -> Mod:
+        return self._mod
+
+    def update(self) -> None:
+        # bobbing motion
+        offset = self._bob_offset()
+        self.rect.centery = self.pos.y + offset * self._bob_direction
+        self._step += self._bob_speed
+        if self._step > self._bob_period:
+            self._step = 0
+            self._bob_direction *= -1
+
+    def _bob_offset(self) -> float:
+        offset = self._bob_period * (
+            self._tween(self._step / self._bob_period) - 0.5)
+        return offset
 
 
 class PistolObject(ItemObject):

--- a/src/mod.py
+++ b/src/mod.py
@@ -4,99 +4,58 @@ import pytweening as tween
 from pygame.math import Vector2
 
 import images
-from typing import Any
-import model
+from typing import Any, Union
 import settings
 import sounds
-from model import Item, Groups, DynamicObject
+from model import DynamicObject
 
 
 class ModID(Enum):
     PISTOL = 0
     SHOTGUN = 1
+    HEALTHPACK = 2
 
 
 class ModLocation(Enum):
-    __order__ = 'ARMS LEGS CHEST HEAD'
+    __order__ = 'ARMS LEGS CHEST HEAD BACKPACK'
     ARMS = 0
     LEGS = 1
     CHEST = 2
     HEAD = 3
+    BACKPACK = 4
 
 
-class Mod(model.Item):
-    def __init__(self,
-                 sid: ModID,
-                 loc: ModLocation,
-                 image: pg.Surface,
-                 groups: model.Groups,
-                 pos: pg.math.Vector2,
+class Mod(object):
+    def __init__(self, sid: ModID, loc: ModLocation, image: pg.Surface,
                  label: str) -> None:
-        super(Mod, self).__init__(groups, pos, label)
         self.sid = sid
         self.loc = loc
         self.mod_image = image
+        self.label = label
 
-    '''this will equip that mod at the proper location'''
+    # TODO (dvirk): Split this logic to two different functions.
+    def use(self, player: Any) -> None:
+        """Either expend the item or move it to its equipped location."""
+        assert self in player.backpack
+        # Remove from backpack
+        player.backpack.remove(self)
 
-    def use(self, player: Any) -> bool:
-        old_mod = None
-        if self.loc in player.active_mods:
-            old_mod = player.active_mods[self.loc]
-        player.active_mods[self.loc] = self
+        if self.equipable:
+            self._move_mod_at_loc_to_backpack(player)
+            player.active_mods[self.loc] = self
 
-        if self in player.backpack:
-            player.backpack.remove(self)
-
+    def _move_mod_at_loc_to_backpack(self, player):
+        old_mod = player.active_mods.pop(self.loc, None)
         if old_mod is not None:
             player.backpack.append(old_mod)
 
-        player.set_weapon(self.label)
+    @property
+    def equipable(self) -> bool:
+        return self.loc != ModLocation.BACKPACK
 
-        return True
-
-
-class ShotgunMod(Mod):
-    def __init__(self, groups: model.Groups, pos: pg.math.Vector2) -> None:
-        sid = ModID.SHOTGUN
-        loc = ModLocation.ARMS
-        img = images.get_image(images.SHOTGUN_MOD)
-        label = settings.SHOTGUN_MOD
-        super(ShotgunMod, self).__init__(sid=sid,
-                                         loc=loc,
-                                         image=img,
-                                         groups=groups,
-                                         pos=pos,
-                                         label=label)
-
-
-class PistolMod(Mod):
-    def __init__(self, groups: model.Groups, pos: pg.math.Vector2) -> None:
-        sid = ModID.PISTOL
-        loc = ModLocation.ARMS
-        img = images.get_image(images.PISTOL_MOD)
-        label = settings.PISTOL_MOD
-        super(PistolMod, self).__init__(sid=sid,
-                                        loc=loc,
-                                        image=img,
-                                        groups=groups,
-                                        pos=pos,
-                                        label=label)
-
-
-class HealthPack(Item):
-    def __init__(self, groups: Groups, pos: pg.math.Vector2) -> None:
-        label = settings.HEALTHPACK_ITEM
-        super(HealthPack, self).__init__(groups, pos, label)
-
-    def use(self, player: Any) -> bool:
-        if player.health < settings.PLAYER_HEALTH:
-            sounds.play(sounds.HEALTH_UP)
-            player.increment_health(settings.HEALTH_PACK_AMOUNT)
-            player.backpack.remove(self)
-            self.kill()
-            return True
-        return False
+    @property
+    def expended(self) -> bool:
+        raise NotImplementedError
 
 
 class ItemObject(DynamicObject):
@@ -136,13 +95,91 @@ class ItemObject(DynamicObject):
         return offset
 
 
+class WeaponMod(Mod):
+    def __init__(self, sid: ModID, image: pg.Surface,
+                 label: str) -> None:
+        loc = ModLocation.ARMS
+        super(WeaponMod, self).__init__(sid=sid, loc=loc, image=image,
+                                        label=label)
+
+    def use(self, player: Any) -> None:
+        super(WeaponMod, self).use(player)
+        player.set_weapon(self.label)
+
+    @property
+    def expended(self):
+        return False
+
+
+class ShotgunMod(WeaponMod):
+    def __init__(self) -> None:
+        sid = ModID.SHOTGUN
+        img = images.get_image(images.SHOTGUN_MOD)
+        label = settings.SHOTGUN
+        super(ShotgunMod, self).__init__(sid=sid, image=img, label=label)
+
+
+class PistolMod(WeaponMod):
+    def __init__(self) -> None:
+        sid = ModID.PISTOL
+        img = images.get_image(images.PISTOL_MOD)
+        label = settings.PISTOL
+        super(PistolMod, self).__init__(sid=sid, image=img, label=label)
+
+
+class HealthPackMod(Mod):
+    def __init__(self) -> None:
+        sid = ModID.HEALTHPACK
+        loc = ModLocation.BACKPACK
+        img = images.get_image(images.HEALTH_PACK)
+        label = settings.HEALTHPACK
+        self._expended = False
+        super(HealthPackMod, self).__init__(sid=sid, loc=loc, image=img,
+                                            label=label)
+
+    def use(self, player: Any) -> None:
+        if player.damaged:
+            sounds.play(sounds.HEALTH_UP)
+            player.increment_health(settings.HEALTH_PACK_AMOUNT)
+            player.backpack.remove(self)
+            self._expended = True
+
+    @property
+    def expended(self) -> bool:
+        return self._expended
+
+
 class PistolObject(ItemObject):
     def __init__(self, pos: Vector2) -> None:
         self._check_class_initialized()
-        mod = PistolMod(self._groups, pos)
+        mod = PistolMod()
 
         # TODO(dkafri): image should not need to be passed to the super.init?
         if self.base_image is None:
             self._init_base_image(images.PISTOL_MOD)
 
         super(PistolObject, self).__init__(mod, self.base_image, pos)
+
+
+class ShotgunObject(ItemObject):
+    def __init__(self, pos: Vector2) -> None:
+        self._check_class_initialized()
+        mod = ShotgunMod()
+
+        # TODO(dkafri): image should not need to be passed to the super.init?
+        if self.base_image is None:
+            self._init_base_image(images.SHOTGUN_MOD)
+
+        super(ShotgunObject, self).__init__(mod, self.base_image, pos)
+
+
+class HealthPackObject(ItemObject):
+    def __init__(self, pos: Vector2) -> None:
+        self._check_class_initialized()
+        mod = HealthPackMod()
+
+        # TODO(dkafri): image should not need to be passed to the super.init?
+        if self.base_image is None:
+            self._init_base_image(images.HEALTH_PACK)
+
+        super(HealthPackObject, self).__init__(mod, self.base_image, pos)

--- a/src/mod.py
+++ b/src/mod.py
@@ -25,6 +25,10 @@ class ModLocation(Enum):
     BACKPACK = 4
 
 
+EQUIP_LOCATIONS = tuple(
+    [loc for loc in ModLocation if loc != ModLocation.BACKPACK])
+
+
 class Mod(object):
     def __init__(self, sid: ModID, loc: ModLocation, image: pg.Surface,
                  label: str) -> None:

--- a/src/mod.py
+++ b/src/mod.py
@@ -30,7 +30,7 @@ class Mod(object):
                  label: str) -> None:
         self.sid = sid
         self.loc = loc
-        self.mod_image = image
+        self.image = image
         self.label = label
 
     # TODO (dvirk): Split this logic to two different functions.

--- a/src/model.py
+++ b/src/model.py
@@ -38,7 +38,7 @@ class Timer(object):
 
 
 class GameObject(pg.sprite.Sprite):
-    """In-game object with a body for collisions and an image.
+    """In-game object with a hit_rect and rect for collisions and an image.
 
     Added functionality derived from Sprite:
     Can be added/removed to Group objects --> add(*groups), remove(*groups).

--- a/src/model.py
+++ b/src/model.py
@@ -2,12 +2,10 @@ from collections import namedtuple
 from typing import Any, Union
 
 import pygame as pg
-import pytweening as tween
 from pygame.math import Vector2
 from pygame.sprite import Group, LayeredUpdates
 
 import images
-import settings
 
 _GroupsBase = namedtuple('_GroupsBase',
                          ('walls', 'bullets', 'items', 'mobs', 'all_sprites'))

--- a/src/model.py
+++ b/src/model.py
@@ -1,12 +1,13 @@
-import pygame as pg
+from collections import namedtuple
 from typing import Any, Union
+
+import pygame as pg
+import pytweening as tween
 from pygame.math import Vector2
 from pygame.sprite import Group, LayeredUpdates
-import pytweening as tween
-import settings
+
 import images
-from collections import namedtuple
-import sounds
+import settings
 
 _GroupsBase = namedtuple('_GroupsBase',
                          ('walls', 'bullets', 'items', 'mobs', 'all_sprites'))
@@ -143,21 +144,6 @@ class Item(pg.sprite.Sprite):
 
     def use(self, player: Any) -> bool:
         raise NotImplementedError
-
-
-class HealthPack(Item):
-    def __init__(self, groups: Groups, pos: pg.math.Vector2,
-                 label: str) -> None:
-        super(HealthPack, self).__init__(groups, pos, label)
-
-    def use(self, player: Any) -> bool:
-        if player.health < settings.PLAYER_HEALTH:
-            sounds.play(sounds.HEALTH_UP)
-            player.increment_health(settings.HEALTH_PACK_AMOUNT)
-            player.backpack.remove(self)
-            self.kill()
-            return True
-        return False
 
 
 def collide_hit_rect_with_rect(game_obj: GameObject,

--- a/src/model.py
+++ b/src/model.py
@@ -59,7 +59,7 @@ class GameObject(pg.sprite.Sprite):
         self.pos = pos
         # Used in sprite collisions other than walls.
         self.rect: pg.Rect = self.image.get_rect()
-        self.rect.center = (pos.x, pos.y)
+        self.rect.center = pos
 
         # Used in wall collisions
         self.hit_rect = hit_rect.copy()
@@ -116,34 +116,6 @@ class DynamicObject(GameObject):
         if not self.dynamic_initialized:
             raise ValueError('DynamicObject class must be initialized before '
                              'instantiating a DynamicObject.')
-
-
-class Item(pg.sprite.Sprite):
-    def __init__(self, groups: Groups, pos: pg.math.Vector2,
-                 label: str) -> None:
-        pg.sprite.Sprite.__init__(self, [groups.all_sprites, groups.items])
-
-        self.image = images.get_item_image(label)
-        self.rect = self.image.get_rect()
-        self.label = label
-        self.pos = pos
-        self.rect.center = pos
-        self.tween = tween.easeInOutSine
-        self.step = 0
-        self.dir = 1
-
-    def update(self) -> None:
-        # bobbing motion
-        offset = settings.BOB_RANGE * (
-            self.tween(self.step / settings.BOB_RANGE) - 0.5)
-        self.rect.centery = self.pos.y + offset * self.dir
-        self.step += settings.BOB_SPEED
-        if self.step > settings.BOB_RANGE:
-            self.step = 0
-            self.dir *= -1
-
-    def use(self, player: Any) -> bool:
-        raise NotImplementedError
 
 
 def collide_hit_rect_with_rect(game_obj: GameObject,

--- a/src/settings.py
+++ b/src/settings.py
@@ -83,7 +83,6 @@ ITEMS_LAYER = 1
 HEALTH_PACK_AMOUNT = 20
 BOB_RANGE = 10
 BOB_SPEED = 0.3
-HEALTHPACK_ITEM = 'health'
 
 # Sounds
 BG_MUSIC = 'espionage.ogg'
@@ -99,6 +98,7 @@ EFFECTS_SOUNDS = {'level_start': 'level_start.wav',
                   'health_up': 'health_pack.wav',
                   'gun_pickup': 'gun_pickup.wav'}
 
-# MODS
-PISTOL_MOD = 'pistol'
-SHOTGUN_MOD = 'shotgun'
+# Items
+PISTOL = 'pistol'
+SHOTGUN = 'shotgun'
+HEALTHPACK = 'healthpack'

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -50,6 +50,27 @@ class ModTest(unittest.TestCase):
 
         Connection.timer.reset()
 
+    def test_make_item_in_groups(self):
+        groups = Connection.groups
+
+        hp = _make_item(settings.HEALTHPACK)
+        self.assertIn(hp, groups.all_sprites)
+        self.assertIn(hp, groups.items)
+        self.assertEqual(len(groups.all_sprites), 1)
+        self.assertEqual(len(groups.items), 1)
+
+        pistol = _make_item(settings.PISTOL)
+        self.assertIn(pistol, groups.all_sprites)
+        self.assertIn(pistol, groups.items)
+        self.assertEqual(len(groups.all_sprites), 2)
+        self.assertEqual(len(groups.items), 2)
+
+        shotgun = _make_item(settings.SHOTGUN)
+        self.assertIn(shotgun, groups.all_sprites)
+        self.assertIn(shotgun, groups.items)
+        self.assertEqual(len(groups.all_sprites), 3)
+        self.assertEqual(len(groups.items), 3)
+
     def test_backpack_full(self) -> None:
         player = _make_player()
         hp = _make_item(settings.HEALTHPACK)

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -75,32 +75,32 @@ class ModTest(unittest.TestCase):
 
         player.gain_item(hp)
 
-        self.assertEqual(len(player.backpack), 1)
+        self.assertIn(hp.mod, player.backpack)
 
         # health is full
         self.assertFalse(player.damaged)
 
-        hp_mod = hp.mod
-        self.assertFalse(hp_mod.expended)
-        hp_mod.use(player)
-        self.assertFalse(hp_mod.expended)
+        self.assertFalse(hp.mod.expended)
+        hp.mod.use(player)
+        self.assertFalse(hp.mod.expended)
 
         # health pack doesn't work if health is full
-        self.assertEqual(len(player.backpack), 1)
-
-        player.increment_health(-settings.HEALTH_PACK_AMOUNT)
-        self.assertTrue(player.damaged)
-        hp_mod.use(player)
-        self.assertTrue(hp_mod.expended)
+        self.assertIn(hp.mod, player.backpack)
 
         # health pack fills health back up and is gone from backpack
+        player.increment_health(-settings.HEALTH_PACK_AMOUNT)
+        self.assertTrue(player.damaged)
+        hp.mod.use(player)
+        self.assertTrue(hp.mod.expended)
+        self.assertNotIn(hp.mod, player.backpack)
         self.assertFalse(player.damaged)
         self.assertEqual(len(player.backpack), 0)
 
+        hp = _make_item(settings.HEALTHPACK)
         player.gain_item(hp)
         player.increment_health(-1)
 
-        hp_mod.use(player)
+        hp.mod.use(player)
 
         # health pack doesn't fill you over max health
         self.assertEqual(player.health, settings.PLAYER_HEALTH)

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -78,13 +78,13 @@ class ModTest(unittest.TestCase):
         # backpack more than once.
         for i in range(player.backpack_size):
             self.assertFalse(player.backpack_full)
-            player.gain_item(hp)
+            player.attempt_pickup(hp)
             self.assertEqual(len(player.backpack), i + 1)
         self.assertEqual(len(player.backpack), player.backpack_size)
         self.assertTrue(player.backpack_full)
 
         # Item not gained since backpack full
-        player.gain_item(hp)
+        player.attempt_pickup(hp)
         self.assertEqual(len(player.backpack), player.backpack_size)
 
     def test_use_health_pack(self) -> None:
@@ -93,7 +93,7 @@ class ModTest(unittest.TestCase):
 
         self.assertEqual(len(player.backpack), 0)
 
-        player.gain_item(hp)
+        player.attempt_pickup(hp)
 
         self.assertIn(hp.mod, player.backpack)
 
@@ -117,7 +117,7 @@ class ModTest(unittest.TestCase):
         self.assertEqual(len(player.backpack), 0)
 
         hp = _make_item(settings.HEALTHPACK)
-        player.gain_item(hp)
+        player.attempt_pickup(hp)
         player.increment_health(-1)
 
         player.expend(hp.mod)
@@ -130,7 +130,7 @@ class ModTest(unittest.TestCase):
         player = _make_player()
         shotgun = _make_item(settings.SHOTGUN)
 
-        player.gain_item(shotgun)
+        player.attempt_pickup(shotgun)
 
         self.assertTrue(shotgun.mod.equipable)
         # nothing installed at arms location -> install shotgun
@@ -142,7 +142,7 @@ class ModTest(unittest.TestCase):
         # adding a second arm mod goes into the backpack
         pistol = _make_item(settings.PISTOL)
 
-        player.gain_item(pistol)
+        player.attempt_pickup(pistol)
         self.assertEqual(len(player.backpack), 1)
         arm_mod = player.active_mods[mod.ModLocation.ARMS]
         self.assertEqual(arm_mod, shotgun.mod)

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -30,7 +30,6 @@ def setUpModule() -> None:
 def _make_player() -> hmn.Player:
     pos = pygame.math.Vector2(0, 0)
     player = hmn.Player(pos)
-    player.set_weapon('pistol')
     return player
 
 
@@ -138,6 +137,7 @@ class ModTest(unittest.TestCase):
         self.assertEqual(len(player.backpack), 0)
         arm_mod = player.active_mods[mod.ModLocation.ARMS]
         self.assertIs(arm_mod, shotgun.mod)
+        self.assertEqual(player._weapon._label, 'shotgun')
 
         # adding a second arm mod goes into the backpack
         pistol = _make_item(settings.PISTOL)
@@ -149,7 +149,7 @@ class ModTest(unittest.TestCase):
         self.assertIn(pistol.mod, player.backpack)
 
         # make sure we can swap the pistol with the shotgun
-        pistol.mod.use(player)
+        player.equip(pistol.mod)
         self.assertEqual(len(player.backpack), 1)
         arm_mod = player.active_mods[mod.ModLocation.ARMS]
         self.assertEqual(arm_mod, pistol.mod)

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -101,7 +101,7 @@ class ModTest(unittest.TestCase):
         self.assertFalse(player.damaged)
 
         self.assertFalse(hp.mod.expended)
-        hp.mod.use(player)
+        player.expend(hp.mod)
         self.assertFalse(hp.mod.expended)
 
         # health pack doesn't work if health is full
@@ -110,7 +110,7 @@ class ModTest(unittest.TestCase):
         # health pack fills health back up and is gone from backpack
         player.increment_health(-settings.HEALTH_PACK_AMOUNT)
         self.assertTrue(player.damaged)
-        hp.mod.use(player)
+        player.expend(hp.mod)
         self.assertTrue(hp.mod.expended)
         self.assertNotIn(hp.mod, player.backpack)
         self.assertFalse(player.damaged)
@@ -120,7 +120,7 @@ class ModTest(unittest.TestCase):
         player.gain_item(hp)
         player.increment_health(-1)
 
-        hp.mod.use(player)
+        player.expend(hp.mod)
 
         # health pack doesn't fill you over max health
         self.assertEqual(player.health, settings.PLAYER_HEALTH)

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -49,7 +49,7 @@ class ModTest(unittest.TestCase):
 
         Connection.timer.reset()
 
-    def test_make_item_in_groups(self):
+    def test_make_item_in_groups(self) -> None:
         groups = Connection.groups
 
         hp = _make_item(settings.HEALTHPACK)

--- a/src/view.py
+++ b/src/view.py
@@ -78,9 +78,7 @@ class DungeonView(object):
         self._night = not self._night
 
     def try_click_mod(self, pos: Tuple[int, int]) -> None:
-        equipables = [loc for loc in mod.ModLocation if
-                      loc != mod.ModLocation.BACKPACK]
-        rects = [self._hud.mod_rects[l] for l in equipables]
+        rects = [self._hud.mod_rects[l] for l in mod.EQUIP_LOCATIONS]
         index = self.clicked_rect_index(rects, pos)
         if index == self.selected_mod:
             self._hud.selected_mod = NO_SELECTION

--- a/src/view.py
+++ b/src/view.py
@@ -42,9 +42,7 @@ class DungeonView(object):
 
         # generate rects for mods/backpack
         self.mod_rects = self.generate_mod_rects()
-        backpack_rects, img_rects = self.generate_backpack_rects()
-        self.backpack_rects = backpack_rects
-        self.backpack_img_rects = img_rects
+        self.backpack_rects = self.generate_backpack_rects()
 
         self._selected_mod = NO_SELECTION
         self._selected_item = NO_SELECTION
@@ -79,22 +77,20 @@ class DungeonView(object):
 
         return rects
 
-    def generate_backpack_rects(self) -> List[List[pg.Rect]]:
+    def generate_backpack_rects(self) -> List[pg.Rect]:
         item_size = 50
         x, y = self._hud_pos
         x += self._bar_length + 3
         y += 4
         rects: List[pg.Rect] = []
-        img_rects: List[pg.Rect] = []
+
         for i in range(4):
             for j in range(2):
                 x_i = x + i * (item_size + 2)
                 y_i = y + j * (item_size + 2)
                 fill_rect = pg.Rect(x_i, y_i, item_size, item_size)
-                img_rect = pg.Rect(x_i + 5, y_i + 15, item_size, item_size)
                 rects.append(fill_rect)
-                img_rects.append(img_rect)
-        return [rects, img_rects]
+        return rects
 
     def set_groups(self, groups: Groups) -> None:
         self._groups = groups
@@ -200,15 +196,17 @@ class DungeonView(object):
                       20, settings.WHITE, r.x + 10, r.y + 10, align="center")
 
     def draw_backpack(self, player: Player) -> None:
-        for idx, r in enumerate(self.backpack_rects):
-            col = settings.HUDDARK
+        for idx, rect in enumerate(self.backpack_rects):
+            color = settings.HUDDARK
             if self._selected_item == idx:
-                col = settings.RED
-            pg.draw.rect(self._screen, col, r, 2)
+                color = settings.RED
+            pg.draw.rect(self._screen, color, rect, 2)
 
-        for idx, item in enumerate(player.backpack):
-            r = self.backpack_img_rects[idx]
-            self._screen.blit(item.image, r)
+        for idx, item_mod in enumerate(player.backpack):
+            rect = self.backpack_rects[idx]
+
+            img = pg.transform.scale(item_mod.image, (rect.w, rect.h))
+            self._screen.blit(img, rect)
 
     def try_click_mod(self, pos: Tuple[int, int]) -> None:
         equipables = [loc for loc in mod.ModLocation if


### PR DESCRIPTION
There are ItemObjects, which are ingame objects that the player picks up. Doing so gives the player a Mod object, which goes either to the backpack or is immediately equipped. The ItemObject is then killed. This deals with the following issues: #86  #75 #67 #55 