### PR TITLE
Remove hit rect

### DIFF
--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -1,11 +1,11 @@
 import abilities
 import mods
-from humanoids import Player, Mob
+from humanoids import Player, Mob, collide_hit_rect_with_rect
 import humanoids
 from pygame.sprite import spritecollide, groupcollide
 from mods import ItemObject
 from model import Obstacle, Groups, GameObject, Timer, \
-    collide_hit_rect_with_rect, DynamicObject, Waypoint
+    DynamicObject, Waypoint
 from item_manager import ItemManager
 from pygame.math import Vector2
 from typing import Dict, List, Tuple

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -13,8 +13,6 @@ import settings
 import sounds
 
 # Player settings
-from model import GameObject
-
 PLAYER_HEALTH = 100
 PLAYER_SPEED = 280
 PLAYER_ROT_SPEED = 200
@@ -40,8 +38,10 @@ class Humanoid(mdl.DynamicObject):
         super().__init__(pos)
 
         # Used in wall collisions
-        self.hit_rect = hit_rect.copy()
-        self.hit_rect.center = self.rect.center
+        self.hit_rect: pg.Rect = hit_rect.copy()
+        # For some reason, mypy cannot infer the type of hit_rect in the line
+        #  below.
+        self.hit_rect.center = self.rect.center  # type: ignore
 
         self._vel = Vector2(0, 0)
         self._acc = Vector2(0, 0)
@@ -82,7 +82,9 @@ class Humanoid(mdl.DynamicObject):
         _collide_hit_rect_in_direction(self, self._walls, 'x')
         self.hit_rect.centery = self.pos.y
         _collide_hit_rect_in_direction(self, self._walls, 'y')
-        self.rect.center = self.hit_rect.center
+        # For some reason, mypy cannot infer the type of hit_rect in the line
+        #  below.
+        self.rect.center = self.hit_rect.center  # type: ignore
 
     def _match_image_to_rot(self) -> None:
         self.image = pg.transform.rotate(self.base_image, self.rot)

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -37,7 +37,12 @@ class Humanoid(mdl.DynamicObject):
     def __init__(self, hit_rect: pg.Rect, pos: Vector2,
                  max_health: int) -> None:
         self._check_class_initialized()
-        super().__init__(hit_rect, pos)
+        super().__init__(pos)
+
+        # Used in wall collisions
+        self.hit_rect = hit_rect.copy()
+        self.hit_rect.center = self.rect.center
+
         self._vel = Vector2(0, 0)
         self._acc = Vector2(0, 0)
         self.rot = 0

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -11,9 +11,10 @@ from typing import Dict
 import model as mdl
 import settings
 import sounds
-from model import collide_hit_rect_with_rect
 
 # Player settings
+from model import GameObject
+
 PLAYER_HEALTH = 100
 PLAYER_SPEED = 280
 PLAYER_ROT_SPEED = 200
@@ -373,3 +374,10 @@ def _collide_hit_rect_in_direction(hmn: Humanoid, group: mdl.Group,
                 hmn.pos.y = hits[0].rect.bottom + hmn.hit_rect.height / 2
             hmn.stop_y()
             hmn.hit_rect.centery = hmn.pos.y
+
+
+def collide_hit_rect_with_rect(humanoid: Humanoid,
+                               sprite: pg.sprite.Sprite) -> bool:
+    """Collide the hit_rect of a GameObject with the rect of a Sprite.
+    """
+    return humanoid.hit_rect.colliderect(sprite.rect)

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -385,6 +385,5 @@ def _collide_hit_rect_in_direction(hmn: Humanoid, group: mdl.Group,
 
 def collide_hit_rect_with_rect(humanoid: Humanoid,
                                sprite: pg.sprite.Sprite) -> bool:
-    """Collide the hit_rect of a GameObject with the rect of a Sprite.
-    """
+    """Collide the hit_rect of a Humanoid with the rect of a Sprite. """
     return humanoid.hit_rect.colliderect(sprite.rect)

--- a/src/model.py
+++ b/src/model.py
@@ -68,7 +68,7 @@ class GameObject(pg.sprite.Sprite):
         self.pos = pos
         # Used in sprite collisions other than walls.
         self.rect: pg.Rect = self.image.get_rect()
-        self.rect.center = (pos.x, pos.y)
+        self.rect.center = pos
 
     def _check_class_initialized(self) -> None:
         if not self.gameobjects_initialized:

--- a/src/model.py
+++ b/src/model.py
@@ -101,10 +101,6 @@ class Obstacle(GameObject):
     def y(self) -> int:
         return self.rect.y
 
-    @property
-    def hit_rect(self) -> pg.Rect:
-        return self.rect
-
 
 class DynamicObject(GameObject):
     """A time-changing GameObject with access to current time information."""

--- a/src/model.py
+++ b/src/model.py
@@ -4,8 +4,9 @@ from typing import Any, Union
 import pygame as pg
 from pygame.math import Vector2
 from pygame.sprite import Group, LayeredUpdates
-import settings
+
 import images
+import settings
 
 _GroupsBase = namedtuple('_GroupsBase',
                          ('walls', 'bullets',
@@ -127,13 +128,6 @@ class DynamicObject(GameObject):
                                ' instantiating a DynamicObject.')
 
 
-def collide_hit_rect_with_rect(game_obj: GameObject,
-                               sprite: pg.sprite.Sprite) -> bool:
-    """Collide the hit_rect of a GameObject with the rect of a Sprite.
-    """
-    return game_obj.hit_rect.colliderect(sprite.rect)
-
-
 # waypoint objects appear as blue spirals on the map (for now).
 # when the player runs into one of these objects they dissappear from the game
 # they can serve as the end of a dungeon or as an area that must be explored
@@ -152,5 +146,5 @@ class Waypoint(DynamicObject):
         pg.sprite.Sprite.__init__(self, waypoint_groups)
 
     def update(self) -> None:
-        if collide_hit_rect_with_rect(self, self.player):
+        if self.rect.colliderect(self.player.rect):
             self.kill()

--- a/src/model.py
+++ b/src/model.py
@@ -61,7 +61,7 @@ class GameObject(pg.sprite.Sprite):
     gameobjects_initialized = False
     _groups: Union[Groups, None] = None
 
-    def __init__(self, hit_rect: pg.Rect, pos: Vector2) -> None:
+    def __init__(self, pos: Vector2) -> None:
 
         self._check_class_initialized()
 
@@ -71,9 +71,7 @@ class GameObject(pg.sprite.Sprite):
         self.rect: pg.Rect = self.image.get_rect()
         self.rect.center = pos
 
-        # Used in wall collisions
-        self.hit_rect = hit_rect.copy()
-        self.hit_rect.center = self.rect.center
+
 
     def _check_class_initialized(self) -> None:
         if not self.gameobjects_initialized:
@@ -139,7 +137,7 @@ class Waypoint(DynamicObject):
 
         hit_rect = pg.Rect(pos.x, pos.y,
                            settings.TILESIZE, settings.TILESIZE)
-        super().__init__(hit_rect, pos)
+        super().__init__(pos)
         self.player = player
 
         waypoint_groups = [self._groups.all_sprites, self._groups.conflicts]

--- a/src/model.py
+++ b/src/model.py
@@ -6,7 +6,6 @@ from pygame.math import Vector2
 from pygame.sprite import Group, LayeredUpdates
 
 import images
-import settings
 
 _GroupsBase = namedtuple('_GroupsBase',
                          ('walls', 'bullets',
@@ -69,9 +68,7 @@ class GameObject(pg.sprite.Sprite):
         self.pos = pos
         # Used in sprite collisions other than walls.
         self.rect: pg.Rect = self.image.get_rect()
-        self.rect.center = pos
-
-
+        self.rect.center = (pos.x, pos.y)
 
     def _check_class_initialized(self) -> None:
         if not self.gameobjects_initialized:
@@ -135,8 +132,6 @@ class Waypoint(DynamicObject):
         base_image = pg.transform.scale(img, (50, 50))
         self.base_image = base_image
 
-        hit_rect = pg.Rect(pos.x, pos.y,
-                           settings.TILESIZE, settings.TILESIZE)
         super().__init__(pos)
         self.player = player
 

--- a/src/model.py
+++ b/src/model.py
@@ -66,7 +66,7 @@ class GameObject(pg.sprite.Sprite):
 
         self.image = self.base_image
         self.pos = pos
-        # Used in sprite collisions other than walls.
+        # Used in sprite collisions
         self.rect: pg.Rect = self.image.get_rect()
         self.rect.center = pos
 

--- a/src/mods.py
+++ b/src/mods.py
@@ -159,7 +159,7 @@ class ItemObject(DynamicObject):
 
     def __init__(self, mod: Mod, image: pg.Surface, pos: Vector2) -> None:
         self._check_class_initialized()
-        super().__init__(image.get_rect(), pos)
+        super().__init__(pos)
 
         my_groups = [self._groups.all_sprites, self._groups.items]
         pg.sprite.Sprite.__init__(self, my_groups)

--- a/src/view.py
+++ b/src/view.py
@@ -8,6 +8,7 @@ import images
 import mods
 
 from hud import HUD
+
 NO_SELECTION = -1
 
 
@@ -50,13 +51,13 @@ class DungeonView(object):
             if isinstance(sprite, Mob):
                 sprite.draw_health()
             self._screen.blit(sprite.image, camera.apply(sprite))
-            if self._draw_debug and hasattr(sprite, 'hit_rect'):
-                sprite_camera = camera.apply_rect(sprite.hit_rect)
+            if self._draw_debug:
+                if hasattr(sprite, 'hit_rect'):
+                    rect = sprite.hit_rect
+                else:
+                    rect = sprite.rect
+                sprite_camera = camera.apply_rect(rect)
                 pg.draw.rect(self._screen, settings.CYAN, sprite_camera, 1)
-        if self._draw_debug:
-            for wall in self._groups.walls:
-                wall_camera = camera.apply_rect(wall.rect)
-                pg.draw.rect(self._screen, settings.CYAN, wall_camera, 1)
 
         if self._night:
             self.render_fog(player, camera)


### PR DESCRIPTION
This is relating to the discussion in #115. @mick-warehime 
The hit_rect is only used in wall collisions of Humanoid objects, so I moved it from 