### PR TITLE
Make backback into a list instead of a dict.

### DIFF
--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -205,7 +205,7 @@ class DungeonController(controller.Controller):
         if idx == view.NO_SELECTION:
             return
 
-        if idx in self.player.backpack:
+        if idx + 1 >= len(self.player.backpack):
             item_in_backpack = self.player.backpack[idx]
             self.player.equip(item_in_backpack)
             self._view.set_selected_item(view.NO_SELECTION)

--- a/src/hud.py
+++ b/src/hud.py
@@ -132,8 +132,7 @@ class HUD(object):
                 color = settings.RED
             pg.draw.rect(self._screen, color, rect, 2)
 
-        for idx in player.backpack:
-            item_mod = player.backpack[idx]
+        for idx, item_mod in enumerate(player.backpack):
             rect = self.backpack_rects[idx]
             img = item_mod.backpack_image
             img_rect = img.get_rect()

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -2,7 +2,7 @@ from itertools import chain
 from random import choice, random
 import pygame as pg
 from pygame.sprite import Group
-from typing import Tuple, Callable
+from typing import Tuple, Callable, List
 import math
 import images
 import mods
@@ -50,7 +50,7 @@ class Humanoid(mdl.DynamicObject):
         self._health = max_health
         self.active_mods: Dict[mods.ModLocation, mods.Mod] = {}
 
-        self.backpack: Dict[int, mdl.Item] = {}
+        self.backpack: List[mods.Mod] = []
         self.backpack_size = 8
 
     @property
@@ -97,8 +97,8 @@ class Humanoid(mdl.DynamicObject):
         self._vel.y = 0
 
     def equip(self, item_mod: mods.Mod) -> None:
-        if item_mod in self.backpack.values():
-            self.remove_from_backpack(item_mod)
+        if item_mod in self.backpack:
+            self.backpack.remove(item_mod)
         self._move_mod_at_loc_to_backpack(item_mod.loc)
         self.active_mods[item_mod.loc] = item_mod
 
@@ -121,24 +121,11 @@ class Humanoid(mdl.DynamicObject):
         if item_mod.expended:
             self.active_mods.pop(item_mod.loc)
 
-    def add_to_backpack(self, item_mod: mods.Mod) -> None:
-        for pocket in range(self.backpack_size):
-            if pocket not in self.backpack:
-                self.backpack[pocket] = item_mod
-                return
-        raise Exception('no room in backpack for %s', item_mod)
-
-    def remove_from_backpack(self, item_mod: mods.Mod) -> None:
-        for pocket in self.backpack:
-            if self.backpack[pocket] == item_mod:
-                del self.backpack[pocket]
-                break
-
     def _move_mod_at_loc_to_backpack(self, loc: mods.ModLocation) -> None:
         assert not self.backpack_full
         old_mod = self.active_mods.pop(loc, None)
         if old_mod is not None:
-            self.add_to_backpack(old_mod)
+            self.backpack.append(old_mod)
 
     def attempt_pickup(self, item: mods.ItemObject) -> None:
 
@@ -146,7 +133,7 @@ class Humanoid(mdl.DynamicObject):
             self.equip(item.mod)
             item.kill()
         elif not self.backpack_full:
-            self.add_to_backpack(item.mod)
+            self.backpack.append(item.mod)
             item.kill()
 
     @property

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -91,7 +91,7 @@ class ModTest(unittest.TestCase):
 
         hp_2 = _make_item(ObjectType.HEALTHPACK)
         player.attempt_pickup(hp_2)
-        self.assertIn(hp_2.mod, player.backpack.values())
+        self.assertIn(hp_2.mod, player.backpack)
 
         # health is full
         self.assertFalse(player.damaged)
@@ -114,7 +114,7 @@ class ModTest(unittest.TestCase):
         use_hp_mod()
 
         self.assertTrue(hp.mod.expended)
-        self.assertNotIn(hp.mod, player.backpack.values())
+        self.assertNotIn(hp.mod, player.backpack)
         self.assertFalse(player.damaged)
         self.assertEqual(len(player.active_mods.values()), 0)
 
@@ -137,7 +137,7 @@ class ModTest(unittest.TestCase):
         player.attempt_pickup(shotgun)
 
         # nothing installed at arms location -> install shotgun
-        self.assertEqual(len(player.backpack.values()), 0)
+        self.assertEqual(len(player.backpack), 0)
         arm_mod = player.active_mods[mods.ModLocation.ARMS]
         self.assertIs(arm_mod, shotgun.mod)
 
@@ -145,17 +145,17 @@ class ModTest(unittest.TestCase):
         pistol = _make_item(ObjectType.PISTOL)
 
         player.attempt_pickup(pistol)
-        self.assertEqual(len(player.backpack.values()), 1)
+        self.assertEqual(len(player.backpack), 1)
         arm_mod = player.active_mods[mods.ModLocation.ARMS]
         self.assertIs(arm_mod, shotgun.mod)
-        self.assertIn(pistol.mod, player.backpack.values())
+        self.assertIn(pistol.mod, player.backpack)
 
         # make sure we can swap the pistol with the shotgun
         player.equip(pistol.mod)
-        self.assertEqual(len(player.backpack.values()), 1)
+        self.assertEqual(len(player.backpack), 1)
         arm_mod = player.active_mods[mods.ModLocation.ARMS]
         self.assertEqual(arm_mod, pistol.mod)
-        self.assertIn(shotgun.mod, player.backpack.values())
+        self.assertIn(shotgun.mod, player.backpack)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Using a dict for backpack instead of a list adds unnecessary complexity. Perhaps we can make an Inventory object that handles both the backpack slots and active mods, as well as the player methods associated with them.