### PR TITLE
Simplify GameObject

### DIFF
--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -90,9 +90,8 @@ class DungeonController(controller.Controller):
         GameObject.initialize_gameobjects(self._groups)
         timer = Timer(self)
         DynamicObject.initialize_dynamic_objects(timer)
-        Player.init_class()
         Mob.init_class(self._map_img)
-        Bullet.initialize_class()
+        # Bullet.initialize_class()
         mods.initialize_classes()
         abilities.initialize_classes(timer)
 

--- a/src/dungeon_controller.py
+++ b/src/dungeon_controller.py
@@ -91,8 +91,6 @@ class DungeonController(controller.Controller):
         timer = Timer(self)
         DynamicObject.initialize_dynamic_objects(timer)
         Mob.init_class(self._map_img)
-        # Bullet.initialize_class()
-        mods.initialize_classes()
         abilities.initialize_classes(timer)
 
     def init_controls(self) -> None:

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -35,6 +35,8 @@ class Humanoid(mdl.DynamicObject):
     def __init__(self, hit_rect: pg.Rect, pos: Vector2,
                  max_health: int) -> None:
         self._check_class_initialized()
+        self._health = max_health
+        self._max_health = max_health
         super().__init__(pos)
         # Used in wall collisions
         self.hit_rect: pg.Rect = hit_rect.copy()
@@ -45,8 +47,8 @@ class Humanoid(mdl.DynamicObject):
         self._vel = Vector2(0, 0)
         self._acc = Vector2(0, 0)
         self.rot = 0
-        self._max_health = max_health
-        self._health = max_health
+
+
         self.active_mods: Dict[mods.ModLocation, mods.Mod] = {}
 
         self.backpack: List[mods.Mod] = []
@@ -279,7 +281,13 @@ class Mob(Humanoid):
     @property
     def image(self) -> pg.Surface:
         base_image = images.get_image(images.MOB_IMG)
-        return pg.transform.rotate(base_image, self.rot)
+        image = pg.transform.rotate(base_image, self.rot)
+        if self.damaged:
+            col = self._health_bar_color()
+            width = int(self.rect.width * self.health / MOB_HEALTH)
+            health_bar = pg.Rect(0, 0, width, 7)
+            pg.draw.rect(image, col, health_bar)
+        return image
 
     def _avoid_mobs(self) -> None:
         for mob in self._mob_group:
@@ -315,17 +323,14 @@ class Mob(Humanoid):
     def _target_close(target_dist: Vector2) -> bool:
         return target_dist.length_squared() < DETECT_RADIUS ** 2
 
-    def draw_health(self) -> None:
+    def _health_bar_color(self):
         if self.health > 60:
             col = settings.GREEN
         elif self.health > 30:
             col = settings.YELLOW
         else:
             col = settings.RED
-        width = int(self.rect.width * self.health / MOB_HEALTH)
-        health_bar = pg.Rect(0, 0, width, 7)
-        if self.damaged:
-            pg.draw.rect(self.image, col, health_bar)
+        return col
 
 
 def _collide_hit_rect_in_direction(hmn: Humanoid, group: mdl.Group,

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -48,7 +48,6 @@ class Humanoid(mdl.DynamicObject):
         self._acc = Vector2(0, 0)
         self.rot = 0
 
-
         self.active_mods: Dict[mods.ModLocation, mods.Mod] = {}
 
         self.backpack: List[mods.Mod] = []
@@ -323,7 +322,7 @@ class Mob(Humanoid):
     def _target_close(target_dist: Vector2) -> bool:
         return target_dist.length_squared() < DETECT_RADIUS ** 2
 
-    def _health_bar_color(self):
+    def _health_bar_color(self) -> tuple:
         if self.health > 60:
             col = settings.GREEN
         elif self.health > 30:

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -36,7 +36,6 @@ class Humanoid(mdl.DynamicObject):
                  max_health: int) -> None:
         self._check_class_initialized()
         super().__init__(pos)
-
         # Used in wall collisions
         self.hit_rect: pg.Rect = hit_rect.copy()
         # For some reason, mypy cannot infer the type of hit_rect in the line
@@ -91,7 +90,6 @@ class Humanoid(mdl.DynamicObject):
         self.rect.center = self.hit_rect.center  # type: ignore
 
     def _match_image_to_rot(self) -> None:
-        self.image = pg.transform.rotate(self.base_image, self.rot)
         self.rect = self.image.get_rect()
 
     def stop_x(self) -> None:
@@ -132,7 +130,6 @@ class Humanoid(mdl.DynamicObject):
             self.backpack.append(old_mod)
 
     def attempt_pickup(self, item: mods.ItemObject) -> None:
-
         if item.mod.loc not in self.active_mods:
             self.equip(item.mod)
             item.kill()
@@ -146,12 +143,9 @@ class Humanoid(mdl.DynamicObject):
 
 
 class Player(Humanoid):
-    class_initialized = True
-
     def __init__(self, pos: Vector2) -> None:
-
         self._check_class_initialized()
-
+        self.rot = 0
         super().__init__(PLAYER_HIT_RECT, pos, PLAYER_HEALTH)
         pg.sprite.Sprite.__init__(self, self._groups.all_sprites)
 
@@ -171,14 +165,8 @@ class Player(Humanoid):
 
     @property
     def image(self) -> pg.Surface:
-        return images.get_image(images.PLAYER_IMG)
-
-    def _check_class_initialized(self) -> None:
-        super()._check_class_initialized()
-        if not self.class_initialized:
-            raise RuntimeError(
-                'Player class must be initialized before an object can be'
-                ' instantiated.')
+        base_image = images.get_image(images.PLAYER_IMG)
+        return pg.transform.rotate(base_image, self.rot)
 
     # translate_direction = slide in that direction
     def translate_up(self) -> None:
@@ -243,12 +231,6 @@ class Player(Humanoid):
 
         self.set_rotation(angle)
 
-    @classmethod
-    def init_class(cls) -> None:
-        if not cls.class_initialized:
-            cls._init_base_image(images.PLAYER_IMG)
-            cls.class_initialized = True
-
 
 class Mob(Humanoid):
     class_initialized = False
@@ -258,7 +240,7 @@ class Mob(Humanoid):
     def __init__(self, pos: Vector2, player: Player, quest: bool) -> None:
 
         self._check_class_initialized()
-
+        self.rot = 0
         super().__init__(MOB_HIT_RECT, pos, MOB_HEALTH)
 
         if quest:
@@ -297,7 +279,8 @@ class Mob(Humanoid):
 
     @property
     def image(self) -> pg.Surface:
-        return images.get_image(images.MOB_IMG)
+        base_image = images.get_image(images.MOB_IMG)
+        return pg.transform.rotate(base_image, self.rot)
 
     def _avoid_mobs(self) -> None:
         for mob in self._mob_group:

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -238,7 +238,6 @@ class Mob(Humanoid):
     _map_img = None
 
     def __init__(self, pos: Vector2, player: Player, quest: bool) -> None:
-
         self._check_class_initialized()
         self.rot = 0
         super().__init__(MOB_HIT_RECT, pos, MOB_HEALTH)

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -65,6 +65,10 @@ class Humanoid(mdl.DynamicObject):
     def damaged(self) -> bool:
         return self.health < self._max_health
 
+    @property
+    def image(self) -> pg.Surface:
+        raise NotImplementedError
+
     def increment_health(self, amount: int) -> None:
         new_health = self._health + amount
         new_health = min(new_health, self._max_health)
@@ -153,12 +157,9 @@ class Humanoid(mdl.DynamicObject):
     def backpack_full(self) -> bool:
         return len(self.backpack) >= self.backpack_size
 
-    def _check_class_initialized(self) -> None:
-        super()._check_class_initialized()
-
 
 class Player(Humanoid):
-    class_initialized = False
+    class_initialized = True
 
     def __init__(self, pos: Vector2) -> None:
 
@@ -180,6 +181,10 @@ class Player(Humanoid):
             return
 
         self.step_forward()
+
+    @property
+    def image(self) -> pg.Surface:
+        return images.get_image(images.PLAYER_IMG)
 
     def _check_class_initialized(self) -> None:
         super()._check_class_initialized()
@@ -298,11 +303,14 @@ class Mob(Humanoid):
     @classmethod
     def init_class(cls, map_img: pg.Surface) -> None:
         if not cls.class_initialized:
-            cls._init_base_image(images.MOB_IMG)
             splat_img = images.get_image(images.SPLAT)
             cls._splat = pg.transform.scale(splat_img, (64, 64))
             cls._map_img = map_img
             cls.class_initialized = True
+
+    @property
+    def image(self) -> pg.Surface:
+        return images.get_image(images.MOB_IMG)
 
     def _avoid_mobs(self) -> None:
         for mob in self._mob_group:
@@ -353,13 +361,6 @@ class Mob(Humanoid):
 
 def _collide_hit_rect_in_direction(hmn: Humanoid, group: mdl.Group,
                                    x_or_y: str) -> None:
-    """
-
-    :param hmn: A sprite object with a hit_rect
-    :param group:
-    :param x_or_y:
-    :return:
-    """
     assert x_or_y == 'x' or x_or_y == 'y'
     if x_or_y == 'x':
         hits = pg.sprite.spritecollide(hmn, group, False,

--- a/src/model.py
+++ b/src/model.py
@@ -84,19 +84,11 @@ class GameObject(pg.sprite.Sprite):
 
 
 class Obstacle(GameObject):
-    def __init__(self, pos: Vector2, w: int, h: int) -> None:
+    def __init__(self, top_left: Vector2, w: int, h: int) -> None:
         self._check_class_initialized()
         pg.sprite.Sprite.__init__(self, self._groups.walls)
 
-        self.rect = pg.Rect(pos.x, pos.y, w, h)
-
-    @property
-    def x(self) -> int:
-        return self.rect.x
-
-    @property
-    def y(self) -> int:
-        return self.rect.y
+        self.rect = pg.Rect(top_left.x, top_left.y, w, h)
 
     @property
     def image(self) -> pg.Surface:

--- a/src/model.py
+++ b/src/model.py
@@ -107,6 +107,9 @@ class Obstacle(GameObject):
         raise RuntimeError('Obstacle image is meant to be drawn in the '
                            'background.')
 
+    def update(self) -> None:
+        raise RuntimeError('Obstacle is not meant to be updated.')
+
 
 class DynamicObject(GameObject):
     """A time-changing GameObject with access to current time information.

--- a/src/model.py
+++ b/src/model.py
@@ -6,6 +6,7 @@ from pygame.math import Vector2
 from pygame.sprite import Group, LayeredUpdates
 
 import images
+from settings import TILESIZE
 
 _GroupsBase = namedtuple('_GroupsBase',
                          ('walls', 'bullets',
@@ -56,7 +57,6 @@ class GameObject(pg.sprite.Sprite):
     alive() : True iff sprite belongs to any group.
 
     """
-    # base_image: Union[pg.Surface, None] = None
     gameobjects_initialized = False
     _groups: Union[Groups, None] = None
 
@@ -73,11 +73,6 @@ class GameObject(pg.sprite.Sprite):
         if not self.gameobjects_initialized:
             raise RuntimeError('GameObject class must be initialized before '
                                'instantiating a GameObject.')
-
-    @classmethod
-    def _init_base_image(cls, image_file: str) -> None:
-        if cls.base_image is None:
-            cls.base_image = images.get_image(image_file)
 
     @classmethod
     def initialize_gameobjects(cls, groups: Groups) -> None:
@@ -112,7 +107,6 @@ class Obstacle(GameObject):
 
 class DynamicObject(GameObject):
     """A time-changing GameObject with access to current time information."""
-
     dynamic_initialized = False
     _timer: Union[Timer, None] = None
 
@@ -136,6 +130,8 @@ class DynamicObject(GameObject):
 # when the player runs into one of these objects they dissappear from the game
 # they can serve as the end of a dungeon or as an area that must be explored
 class Waypoint(DynamicObject):
+    _image = None
+
     def __init__(self, pos: Vector2, player: Any) -> None:
         super().__init__(pos)
         self.player = player
@@ -149,4 +145,7 @@ class Waypoint(DynamicObject):
 
     @property
     def image(self) -> pg.Surface:
-        return images.get_image(images.WAYPOINT_IMG)
+        if Waypoint._image is None:
+            img = images.get_image(images.WAYPOINT_IMG)
+            Waypoint._image = pg.transform.scale(img, (TILESIZE,TILESIZE))
+        return self._image

--- a/src/model.py
+++ b/src/model.py
@@ -56,6 +56,18 @@ class GameObject(pg.sprite.Sprite):
     update() method that is referenced when a group is updated.
     alive() : True iff sprite belongs to any group.
 
+    Instructions for subclassing GameObject:
+
+    In the __init__:
+      Make sure to call `self._check_class_initialized()'
+      Before calling super().__init__(pos), make sure that all attributes
+      necessary to access the image property are initialized.
+    Note:
+      By default, the rect attribute will be a copy of the image's original
+      rect.
+
+    GameObject.initialize_gameobjects() must be called before instantiating any
+    subclasses.
     """
     gameobjects_initialized = False
     _groups: Union[Groups, None] = None
@@ -97,7 +109,14 @@ class Obstacle(GameObject):
 
 
 class DynamicObject(GameObject):
-    """A time-changing GameObject with access to current time information."""
+    """A time-changing GameObject with access to current time information.
+
+    Instructions for subclassing:
+    Follow instructions for GameObject.
+
+    DynamicObject.initialize_dynamic_objects() must be called before
+    instantiating any subclasses.
+    """
     dynamic_initialized = False
     _timer: Union[Timer, None] = None
 

--- a/src/model.py
+++ b/src/model.py
@@ -61,13 +61,12 @@ class GameObject(pg.sprite.Sprite):
     _groups: Union[Groups, None] = None
 
     def __init__(self, pos: Vector2) -> None:
-
         self._check_class_initialized()
 
-        self.pos = pos
+        self.pos = Vector2(pos.x, pos.y)
         # Used in sprite collisions
         self.rect: pg.Rect = self.image.get_rect().copy()
-        self.rect.center = pos
+        self.rect.center = Vector2(pos.x, pos.y)
 
     def _check_class_initialized(self) -> None:
         if not self.gameobjects_initialized:
@@ -147,5 +146,5 @@ class Waypoint(DynamicObject):
     def image(self) -> pg.Surface:
         if Waypoint._image is None:
             img = images.get_image(images.WAYPOINT_IMG)
-            Waypoint._image = pg.transform.scale(img, (TILESIZE,TILESIZE))
+            Waypoint._image = pg.transform.scale(img, (TILESIZE, TILESIZE))
         return self._image

--- a/src/model.py
+++ b/src/model.py
@@ -66,7 +66,7 @@ class GameObject(pg.sprite.Sprite):
 
         self.pos = pos
         # Used in sprite collisions
-        self.rect: pg.Rect = self.image.get_rect()
+        self.rect: pg.Rect = self.image.get_rect().copy()
         self.rect.center = pos
 
     def _check_class_initialized(self) -> None:

--- a/src/mods.py
+++ b/src/mods.py
@@ -157,14 +157,13 @@ class HealthPackMod(Mod):
 class ItemObject(DynamicObject):
     """A bobbing in-game object that can be picked up."""
 
-    def __init__(self, mod: Mod, image: pg.Surface, pos: Vector2) -> None:
+    def __init__(self, mod: Mod, pos: Vector2) -> None:
         self._check_class_initialized()
         super().__init__(pos)
 
         my_groups = [self._groups.all_sprites, self._groups.items]
         pg.sprite.Sprite.__init__(self, my_groups)
 
-        self.image = image
         self._mod = mod
         self._tween = tween.easeInOutSine
         self._step = 0.0
@@ -190,16 +189,21 @@ class ItemObject(DynamicObject):
             self._tween(self._step / self._bob_period) - 0.5)
         return offset
 
+    @property
+    def image(self) -> pg.Surface:
+        raise NotImplementedError
+
 
 class PistolObject(ItemObject):
     def __init__(self, pos: Vector2) -> None:
         self._check_class_initialized()
         mod = PistolMod()
 
-        if self.base_image is None:
-            self._init_base_image(images.PISTOL)
+        super().__init__(mod, pos)
 
-        super().__init__(mod, self.base_image, pos)
+    @property
+    def image(self) -> pg.Surface:
+        return images.get_image(images.PISTOL)
 
 
 class ShotgunObject(ItemObject):
@@ -207,10 +211,11 @@ class ShotgunObject(ItemObject):
         self._check_class_initialized()
         mod = ShotgunMod()
 
-        if self.base_image is None:
-            self._init_base_image(images.SHOTGUN)
+        super().__init__(mod, pos)
 
-        super().__init__(mod, self.base_image, pos)
+    @property
+    def image(self) -> pg.Surface:
+        return images.get_image(images.SHOTGUN)
 
 
 class HealthPackObject(ItemObject):
@@ -218,7 +223,8 @@ class HealthPackObject(ItemObject):
         self._check_class_initialized()
         mod = HealthPackMod()
 
-        if self.base_image is None:
-            self._init_base_image(images.HEALTH_PACK)
+        super().__init__(mod, pos)
 
-        super().__init__(mod, self.base_image, pos)
+    @property
+    def image(self) -> pg.Surface:
+        return images.get_image(images.HEALTH_PACK)

--- a/src/mods.py
+++ b/src/mods.py
@@ -20,15 +20,7 @@ class ModLocation(Enum):
     HEAD = 3
 
 
-def initialize_classes() -> None:
-    PistolMod.initialize_class()
-    ShotgunMod.initialize_class()
-    HealthPackMod.initialize_class()
-
-
 class Mod(object):
-    class_initialized = True
-
     @property
     def loc(self) -> ModLocation:
         raise NotImplementedError
@@ -49,21 +41,11 @@ class Mod(object):
     def backpack_image(self) -> pg.Surface:
         raise NotImplementedError
 
-    @classmethod
-    def _check_class_initialized(cls) -> None:
-        if not cls.class_initialized:
-            raise RuntimeError('Class %s must be initialized before '
-                               'instantiating an object.' % (cls,))
-
 
 class ShotgunMod(Mod):
     loc = ModLocation.ARMS
-    _equipped_image = None
-    _backpack_image = None
-    class_initialized = False
 
     def __init__(self) -> None:
-        self._check_class_initialized()
         self._ability = FireShotgun()
 
     @property
@@ -74,29 +56,19 @@ class ShotgunMod(Mod):
     def expended(self) -> bool:
         return False
 
-    @classmethod
-    def initialize_class(cls) -> None:
-        cls._equipped_image = images.get_image(images.SHOTGUN_MOD)
-        cls._backpack_image = images.get_image(images.SHOTGUN)
-        cls.class_initialized = True
-
     @property
     def equipped_image(self) -> pg.Surface:
-        return self._equipped_image
+        return images.get_image(images.SHOTGUN_MOD)
 
     @property
     def backpack_image(self) -> pg.Surface:
-        return self._backpack_image
+        return images.get_image(images.SHOTGUN)
 
 
 class PistolMod(Mod):
     loc = ModLocation.ARMS
-    _equipped_image = None
-    _backpack_image = None
-    class_initialized = False
 
     def __init__(self) -> None:
-        self._check_class_initialized()
         self._ability = FirePistol()
 
     @property
@@ -107,28 +79,19 @@ class PistolMod(Mod):
     def expended(self) -> bool:
         return False
 
-    @classmethod
-    def initialize_class(cls) -> None:
-        cls._equipped_image = images.get_image(images.PISTOL_MOD)
-        cls._backpack_image = images.get_image(images.PISTOL)
-        cls.class_initialized = True
-
     @property
     def equipped_image(self) -> pg.Surface:
-        return self._equipped_image
+        return images.get_image(images.PISTOL_MOD)
 
     @property
     def backpack_image(self) -> pg.Surface:
-        return self._backpack_image
+        return images.get_image(images.PISTOL)
 
 
 class HealthPackMod(Mod):
     loc = ModLocation.CHEST
-    _backpack_image = None
-    class_initialized = False
 
     def __init__(self) -> None:
-        self._check_class_initialized()
         self._expended = False
         self._ability = Heal(1, HEALTH_PACK_AMOUNT)
 
@@ -136,22 +99,17 @@ class HealthPackMod(Mod):
     def ability(self) -> Ability:
         return self._ability
 
-    @classmethod
-    def initialize_class(cls) -> None:
-        cls._backpack_image = images.get_image(images.HEALTH_PACK)
-        cls.class_initialized = True
-
     @property
     def expended(self) -> bool:
         return self._ability.uses_left <= 0
 
     @property
     def backpack_image(self) -> pg.Surface:
-        return self._backpack_image
+        return images.get_image(images.HEALTH_PACK)
 
     @property
     def equipped_image(self) -> pg.Surface:
-        return self._backpack_image
+        return images.get_image(images.HEALTH_PACK)
 
 
 class ItemObject(DynamicObject):

--- a/src/test/pygame_mock.py
+++ b/src/test/pygame_mock.py
@@ -59,5 +59,4 @@ def initialize_gameobjects(groups: model.Groups, timer: model.Timer) -> None:
     model.DynamicObject.initialize_dynamic_objects(timer)
     blank_screen = pygame.Surface((800, 600))
     hmn.Mob.init_class(blank_screen)
-    mods.initialize_classes()
     abilities.initialize_classes(timer)

--- a/src/test/pygame_mock.py
+++ b/src/test/pygame_mock.py
@@ -57,9 +57,7 @@ def initialize_pygame() -> None:
 def initialize_gameobjects(groups: model.Groups, timer: model.Timer) -> None:
     model.GameObject.initialize_gameobjects(groups)
     model.DynamicObject.initialize_dynamic_objects(timer)
-    hmn.Player.init_class()
     blank_screen = pygame.Surface((800, 600))
     hmn.Mob.init_class(blank_screen)
     mods.initialize_classes()
     abilities.initialize_classes(timer)
-    weapons.initialize_classes()

--- a/src/test/test_a_initializations.py
+++ b/src/test/test_a_initializations.py
@@ -38,6 +38,7 @@ def _make_mob(player: Union[hmn.Player, None] = None,
 
 def setUpModule() -> None:
     initialize_pygame()
+    _initialization_tests()
 
 
 def _initialization_tests() -> None:
@@ -52,16 +53,7 @@ def _initialization_tests() -> None:
     hmn.Mob.init_class(blank_screen)
     _assert_runtime_exception_raised(CoolDownAbility)
     CoolDownAbility.initialize_class(InitsTest.timer)
-    player = _make_player()
-    fire_pistol = FirePistol()
 
-    def shoot() -> None:
-        fire_pistol.use(player)
-
-    _assert_runtime_exception_raised(shoot)
-    # I would call this in test_mods.py, but it looks like the coverage
-    # command somehow initializes ShotgunMod too early there.
-    _assert_runtime_exception_raised(ShotgunMod)
     InitsTest.groups.empty()
     InitsTest.timer.reset()
 
@@ -72,7 +64,8 @@ def _assert_runtime_exception_raised(tested_fun: Callable) -> None:
         tested_fun()
     except RuntimeError:
         exception_raised = True
-    assert exception_raised
+    assert exception_raised, 'Expected a RuntimeError to be raised for ' \
+                             'function call %s' % (tested_fun,)
 
 
 class InitsTest(unittest.TestCase):
@@ -85,8 +78,6 @@ class InitsTest(unittest.TestCase):
 
     def test_pass(self) -> None:
         pass
-
-
 
 
 if __name__ == '__main__':

--- a/src/test/test_a_initializations.py
+++ b/src/test/test_a_initializations.py
@@ -47,8 +47,6 @@ def _initialization_tests() -> None:
     model.GameObject.initialize_gameobjects(InitsTest.groups)
     _assert_runtime_exception_raised(_make_player)
     model.DynamicObject.initialize_dynamic_objects(InitsTest.timer)
-    _assert_runtime_exception_raised(_make_player)
-    hmn.Player.init_class()
     _assert_runtime_exception_raised(_make_mob)
     blank_screen = pygame.Surface((800, 600))
     hmn.Mob.init_class(blank_screen)
@@ -61,7 +59,6 @@ def _initialization_tests() -> None:
         fire_pistol.use(player)
 
     _assert_runtime_exception_raised(shoot)
-    Bullet.initialize_class()
     # I would call this in test_mods.py, but it looks like the coverage
     # command somehow initializes ShotgunMod too early there.
     _assert_runtime_exception_raised(ShotgunMod)

--- a/src/test/test_humanoid.py
+++ b/src/test/test_humanoid.py
@@ -214,14 +214,9 @@ class HumanoidsTest(unittest.TestCase):
     def test_mob_damage_and_death(self) -> None:
         groups = self.groups
         mob = _make_mob()
-        mob.draw_health()
-
         mob.increment_health(61 - mob._max_health)
-        mob.draw_health()
         mob.increment_health(31 - 61)
-        mob.draw_health()
         mob.increment_health(0 - 31)
-        mob.draw_health()
 
         self.assertIn(mob, groups.mobs)
 

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 import pygame
+from pygame.math import Vector2
+
 import humanoids as hmn
 import mods
 import model
@@ -28,7 +30,7 @@ def _make_player() -> hmn.Player:
 
 
 def _make_item(label: str) -> mods.ItemObject:
-    pos = (0, 0)
+    pos = Vector2(0, 0)
     return ItemManager.item(pos, label)
 
 

--- a/src/test/test_weapons.py
+++ b/src/test/test_weapons.py
@@ -39,6 +39,7 @@ class WeaponsTest(unittest.TestCase):
 
     def test_fire_projectile_distance_independent_of_count(self) -> None:
         player = _make_player()
+        num_updates = 100
 
         FireShotgun._projectile_count = 1
         fire_little_bullet = FireShotgun()
@@ -49,7 +50,7 @@ class WeaponsTest(unittest.TestCase):
         bullet = self.groups.bullets.sprites()[0]
         first_pos = Vector2(bullet.pos.x, bullet.pos.y)
 
-        for _ in range(100):
+        for _ in range(num_updates):
             self.groups.bullets.update()
 
         one_disp = (bullet.pos - first_pos).length()
@@ -63,7 +64,7 @@ class WeaponsTest(unittest.TestCase):
         bullet = self.groups.bullets.sprites()[0]
         first_pos = Vector2(bullet.pos.x, bullet.pos.y)
 
-        for _ in range(100):
+        for _ in range(num_updates):
             self.groups.bullets.update()
 
         many_disp = (bullet.pos - first_pos).length()

--- a/src/test/test_weapons.py
+++ b/src/test/test_weapons.py
@@ -1,0 +1,71 @@
+import unittest
+import os
+
+from pygame.math import Vector2
+
+import model
+import humanoids as hmn
+from abilities import FireShotgun
+from mods import ShotgunObject, ModLocation
+from src.test.pygame_mock import MockTimer, Pygame, initialize_pygame, \
+    initialize_gameobjects
+
+# This allows for running tests without actually generating a screen display
+# or audio output.
+os.environ['SDL_VIDEODRIVER'] = 'dummy'
+os.environ['SDL_AUDIODRIVER'] = 'dummy'
+
+pg = Pygame()
+
+
+def setUpModule() -> None:
+    initialize_pygame()
+    initialize_gameobjects(WeaponsTest.groups, WeaponsTest.timer)
+
+
+def _make_player() -> hmn.Player:
+    pos = Vector2(0, 0)
+    player = hmn.Player(pos)
+    return player
+
+
+class WeaponsTest(unittest.TestCase):
+    groups = model.Groups()
+    timer = MockTimer()
+
+    def tearDown(self) -> None:
+        self.groups.empty()
+        self.timer.reset()
+
+    def test_fire_projectile_distance_independent_of_count(self) -> None:
+        player = _make_player()
+
+        FireShotgun._projectile_count = 1
+        fire_little_bullet = FireShotgun()
+
+        fire_little_bullet.use(player)
+
+        self.assertEqual(len(self.groups.bullets), 1)
+        bullet = self.groups.bullets.sprites()[0]
+        first_pos = Vector2(bullet.pos.x, bullet.pos.y)
+
+        for _ in range(100):
+            self.groups.bullets.update()
+
+        one_disp = (bullet.pos - first_pos).length()
+
+        many = 10
+        FireShotgun._projectile_count = many
+        self.groups.bullets.empty()
+        fire_little_bullet.use(player)
+        self.assertEqual(len(self.groups.bullets), many)
+
+        bullet = self.groups.bullets.sprites()[0]
+        first_pos = Vector2(bullet.pos.x, bullet.pos.y)
+
+        for _ in range(100):
+            self.groups.bullets.update()
+
+        many_disp = (bullet.pos - first_pos).length()
+
+        self.assertLess(0.5 * many_disp, one_disp)

--- a/src/view.py
+++ b/src/view.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 import settings
 import pygame as pg
 from humanoids import Player
-from model import Groups, Obstacle
+from model import Groups
 from tilemap import Camera, TiledMap
 import images
 import mods
@@ -59,7 +59,7 @@ class DungeonView(object):
         # draw hud on top of everything
         self._hud.draw(player)
 
-    def _draw_debug_rects(self, camera):
+    def _draw_debug_rects(self, camera: Camera) -> None:
         for sprite in self._groups.all_sprites:
             if hasattr(sprite, 'hit_rect'):
                 rect = sprite.hit_rect

--- a/src/view.py
+++ b/src/view.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 import settings
 import pygame as pg
-from humanoids import Mob, Player
+from humanoids import Player
 from model import Groups
 from tilemap import Camera, TiledMap
 import images

--- a/src/view.py
+++ b/src/view.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 import settings
 import pygame as pg
 from humanoids import Player
-from model import Groups
+from model import Groups, Obstacle
 from tilemap import Camera, TiledMap
 import images
 import mods
@@ -49,19 +49,28 @@ class DungeonView(object):
 
         for sprite in self._groups.all_sprites:
             self._screen.blit(sprite.image, camera.apply(sprite))
-            if self._draw_debug:
-                if hasattr(sprite, 'hit_rect'):
-                    rect = sprite.hit_rect
-                else:
-                    rect = sprite.rect
-                sprite_camera = camera.apply_rect(rect)
-                pg.draw.rect(self._screen, settings.CYAN, sprite_camera, 1)
+
+        if self._draw_debug:
+            self._draw_debug_rects(camera)
 
         if self._night:
             self.render_fog(player, camera)
 
         # draw hud on top of everything
         self._hud.draw(player)
+
+    def _draw_debug_rects(self, camera):
+        for sprite in self._groups.all_sprites:
+            if hasattr(sprite, 'hit_rect'):
+                rect = sprite.hit_rect
+            else:
+                rect = sprite.rect
+            sprite_camera = camera.apply_rect(rect)
+            pg.draw.rect(self._screen, settings.CYAN, sprite_camera, 1)
+        for obstacle in self._groups.walls:
+            assert obstacle not in self._groups.all_sprites
+            sprite_camera = camera.apply_rect(obstacle.rect)
+            pg.draw.rect(self._screen, settings.CYAN, sprite_camera, 1)
 
     def render_fog(self, player: Player, camera: Camera) -> None:
         # draw the light mask (gradient) onto fog image

--- a/src/view.py
+++ b/src/view.py
@@ -48,8 +48,6 @@ class DungeonView(object):
         self._screen.blit(map_img, camera.apply(map))
 
         for sprite in self._groups.all_sprites:
-            if isinstance(sprite, Mob):
-                sprite.draw_health()
             self._screen.blit(sprite.image, camera.apply(sprite))
             if self._draw_debug:
                 if hasattr(sprite, 'hit_rect'):

--- a/src/weapons.py
+++ b/src/weapons.py
@@ -14,19 +14,16 @@ def initialize_classes() -> None:
 class Bullet(DynamicObject):
     """A projectile fired from weapon. Projectile size is subclass dependent.
     """
-    class_initialized = False
+    class_initialized = True
     max_lifetime: int = 0
     speed: int = 0
     damage: int = 0
-    small_base_image = None
 
     def __init__(self, pos: Vector2, direction: Vector2) -> None:
         self._check_class_initialized()
+        super().__init__(pos)
         groups_list = [self._groups.all_sprites, self._groups.bullets]
         pg.sprite.Sprite.__init__(self, groups_list)
-        self.rect = self.image.get_rect()
-        self.pos = Vector2(pos)
-        self.rect.center = pos
 
         self._vel = direction * self.speed * uniform(0.9, 1.1)
         self.spawn_time = self._timer.current_time
@@ -69,7 +66,7 @@ class BigBullet(Bullet):
 
     @property
     def image(self) -> pg.Surface:
-        return self.base_image
+        return images.get_image(images.BULLET_IMG)
 
 
 class LittleBullet(Bullet):
@@ -77,29 +74,33 @@ class LittleBullet(Bullet):
     max_lifetime = 500
     speed = 400
     damage = 25
+    _base_image = None
 
     @property
     def image(self) -> pg.Surface:
-        return self.small_base_image
+        if LittleBullet._base_image is None:
+            bullet_img = images.get_image(images.BULLET_IMG)
+            small_img = pg.transform.scale(bullet_img, (10, 10))
+            LittleBullet._base_image = small_img
+        return self._base_image
 
 
 class MuzzleFlash(DynamicObject):
     def __init__(self, pos: Vector2) -> None:
         self._check_class_initialized()
         pg.sprite.Sprite.__init__(self, self._groups.all_sprites)
-        size = randint(20, 50)
-
-        flash_img = images.get_muzzle_flash()
-        self.image = pg.transform.scale(flash_img, (size, size))
-
-        self.rect = self.image.get_rect()
-        self.pos = pos
-        self.rect.center = pos
+        super().__init__(pos)
         self._spawn_time = self._timer.current_time
 
     def update(self) -> None:
         if self._fade_out():
             self.kill()
+
+    @property
+    def image(self) -> pg.Surface:
+        size = randint(20, 50)
+        flash_img = images.get_muzzle_flash()
+        return pg.transform.scale(flash_img, (size, size))
 
     def _fade_out(self) -> bool:
         time_elapsed = self._timer.current_time - self._spawn_time

--- a/src/weapons.py
+++ b/src/weapons.py
@@ -45,7 +45,7 @@ class Bullet(DynamicObject):
 class BigBullet(Bullet):
     """A large bullet coming out of a pistol."""
     max_lifetime = 1000
-    speed = 500
+    speed = 400
     damage = 75
 
     @property
@@ -56,7 +56,7 @@ class BigBullet(Bullet):
 class LittleBullet(Bullet):
     """A small bullet coming out of a shotgun."""
     max_lifetime = 500
-    speed = 100
+    speed = 500
     damage = 25
     _image = None
 

--- a/src/weapons.py
+++ b/src/weapons.py
@@ -20,6 +20,7 @@ class Bullet(DynamicObject):
         groups_list = [self._groups.all_sprites, self._groups.bullets]
         pg.sprite.Sprite.__init__(self, groups_list)
 
+        assert direction.is_normalized()
         self._vel = direction * self.speed * uniform(0.9, 1.1)
         self.spawn_time = self._timer.current_time
 
@@ -55,7 +56,7 @@ class BigBullet(Bullet):
 class LittleBullet(Bullet):
     """A small bullet coming out of a shotgun."""
     max_lifetime = 500
-    speed = 400
+    speed = 100
     damage = 25
     _image = None
 

--- a/src/weapons.py
+++ b/src/weapons.py
@@ -7,14 +7,9 @@ import settings
 import images
 
 
-def initialize_classes() -> None:
-    Bullet.initialize_class()
-
-
 class Bullet(DynamicObject):
     """A projectile fired from weapon. Projectile size is subclass dependent.
     """
-    class_initialized = True
     max_lifetime: int = 0
     speed: int = 0
     damage: int = 0
@@ -45,18 +40,6 @@ class Bullet(DynamicObject):
         lifetime = self._timer.current_time - self.spawn_time
         return lifetime > self.max_lifetime
 
-    @classmethod
-    def initialize_class(cls) -> None:
-        cls._init_base_image(images.BULLET_IMG)
-        cls.small_base_image = pg.transform.scale(cls.base_image, (10, 10))
-        cls.class_initialized = True
-
-    def _check_class_initialized(self) -> None:
-        super(Bullet, self)._check_class_initialized()
-        if not self.class_initialized:
-            raise RuntimeError('Bullets class must be initialized before '
-                               'instantiating a Bullet.')
-
 
 class BigBullet(Bullet):
     """A large bullet coming out of a pistol."""
@@ -74,15 +57,15 @@ class LittleBullet(Bullet):
     max_lifetime = 500
     speed = 400
     damage = 25
-    _base_image = None
+    _image = None
 
     @property
     def image(self) -> pg.Surface:
-        if LittleBullet._base_image is None:
+        if LittleBullet._image is None:
             bullet_img = images.get_image(images.BULLET_IMG)
             small_img = pg.transform.scale(bullet_img, (10, 10))
-            LittleBullet._base_image = small_img
-        return self._base_image
+            LittleBullet._image = small_img
+        return self._image
 
 
 class MuzzleFlash(DynamicObject):

--- a/src/weapons.py
+++ b/src/weapons.py
@@ -25,7 +25,6 @@ class Bullet(DynamicObject):
         groups_list = [self._groups.all_sprites, self._groups.bullets]
         pg.sprite.Sprite.__init__(self, groups_list)
         self.rect = self.image.get_rect()
-        self.hit_rect = self.rect
         self.pos = Vector2(pos)
         self.rect.center = pos
 


### PR DESCRIPTION
Simplify implementation of GameObject class. We no longer need to initialize base_image for each subclass of GameObject. Instead all is required is an image property to be implemented by the subclass. I also added straightforward instructions for how to subclass GameObject and DynamicObject.

This addresses issue #115 
@mick-warehime 