### PR TITLE
Make mods stackable

### DIFF
--- a/src/hud.py
+++ b/src/hud.py
@@ -129,7 +129,8 @@ class HUD(object):
             if mod.stackable:
                 self._draw_mod_ammo(img_rect, mod, title_font)
 
-    def _draw_mod_ammo(self, img_rect, mod, title_font):
+    def _draw_mod_ammo(self, img_rect: pg.Surface, mod: mods.Mod,
+                       title_font: str) -> None:
         assert hasattr(mod.ability, 'uses_left')
         num_uses = mod.ability.uses_left
 

--- a/src/hud.py
+++ b/src/hud.py
@@ -112,7 +112,8 @@ class HUD(object):
             pg.draw.rect(self._screen, col, r, 2)
 
         for idx, loc in enumerate(player.active_mods):
-            img = player.active_mods[loc].equipped_image
+            mod = player.active_mods[loc]
+            img = mod.equipped_image
 
             img = pg.transform.scale(img, (50, 50))
 
@@ -124,6 +125,19 @@ class HUD(object):
             draw_text(self._screen, str(idx + 1), title_font,
                       20, settings.WHITE, img_rect.x, img_rect.y,
                       align="center")
+
+            if mod.stackable:
+                self._draw_mod_ammo(img_rect, mod, title_font)
+
+    def _draw_mod_ammo(self, img_rect, mod, title_font):
+        assert hasattr(mod.ability, 'uses_left')
+        num_uses = mod.ability.uses_left
+
+        x_coord = img_rect.x + img_rect.width
+        y_coord = img_rect.y + img_rect.height
+        draw_text(self._screen, str(num_uses), title_font,
+                  20, settings.RED, x_coord, y_coord,
+                  align="center")
 
     def draw_backpack(self, player: Player) -> None:
         for idx, rect in enumerate(self.backpack_rects):
@@ -141,3 +155,7 @@ class HUD(object):
             img_rect.center = rect.center
 
             self._screen.blit(img, img_rect)
+
+            if item_mod.stackable:
+                self._draw_mod_ammo(img_rect, item_mod,
+                                    images.get_font(images.ZOMBIE_FONT))

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -125,7 +125,7 @@ class Humanoid(mdl.DynamicObject):
         mod_at_loc = self.active_mods[item.mod.loc]
 
         if isinstance(mod_at_loc, type(item.mod)) and item.mod.stackable:
-            mod_at_loc.increment_uses(item.mod.ability.num_uses)
+            mod_at_loc.increment_uses(item.mod.ability.uses_left)
             item.kill()
             return
 

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -166,7 +166,7 @@ class Backpack(object):
         matching_mods = [md for md in self._slots if isinstance(md, type(mod))]
         if matching_mods and mod.stackable:
             assert len(matching_mods) == 1
-            matching_mods[0].increment_uses(mod.ability.num_uses)
+            matching_mods[0].increment_uses(mod.ability.uses_left)
             return
 
         self._slots[self._first_empty_slot()] = mod

--- a/src/humanoids.py
+++ b/src/humanoids.py
@@ -121,9 +121,18 @@ class Humanoid(mdl.DynamicObject):
         if item.mod.loc not in self.active_mods:
             self.equip(item.mod)
             item.kill()
-        elif not self.backpack.is_full:
+            return
+        mod_at_loc = self.active_mods[item.mod.loc]
+
+        if isinstance(mod_at_loc, type(item.mod)) and item.mod.stackable:
+            mod_at_loc.increment_uses(item.mod.ability.num_uses)
+            item.kill()
+            return
+
+        if not self.backpack.is_full:
             self.backpack.add_mod(item.mod)
             item.kill()
+            return
 
     def _move_mod_at_loc_to_backpack(self, loc: mods.ModLocation) -> None:
         assert not self.backpack.is_full
@@ -154,6 +163,12 @@ class Backpack(object):
         return self._slots_filled == self.size
 
     def add_mod(self, mod: mods.Mod) -> None:
+        matching_mods = [md for md in self._slots if isinstance(md, type(mod))]
+        if matching_mods and mod.stackable:
+            assert len(matching_mods) == 1
+            matching_mods[0].increment_uses(mod.ability.num_uses)
+            return
+
         self._slots[self._first_empty_slot()] = mod
         self._slots_filled += 1
 

--- a/src/items/rocks.py
+++ b/src/items/rocks.py
@@ -59,6 +59,10 @@ class RockMod(Mod):
         return self._ability.num_uses <= 0
 
     @property
+    def stackable(self) -> bool:
+        return True
+
+    @property
     def equipped_image(self) -> pg.Surface:
         return images.get_image(images.ROCK)
 

--- a/src/items/rocks.py
+++ b/src/items/rocks.py
@@ -37,11 +37,11 @@ class ThrowRock(FireProjectile):
 
     def __init__(self) -> None:
         super().__init__()
-        self.num_uses = 1
+        self.uses_left = 1
 
     def _fire_effects(self, origin: Vector2) -> None:
         sounds.play('grunt')
-        self.num_uses -= 1
+        self.uses_left -= 1
 
 
 class RockMod(Mod):
@@ -56,7 +56,7 @@ class RockMod(Mod):
 
     @property
     def expended(self) -> bool:
-        return self._ability.num_uses <= 0
+        return self._ability.uses_left <= 0
 
     @property
     def stackable(self) -> bool:

--- a/src/mods.py
+++ b/src/mods.py
@@ -35,12 +35,21 @@ class Mod(object):
         raise NotImplementedError
 
     @property
+    def stackable(self) -> bool:
+        raise NotImplementedError
+
+    @property
     def equipped_image(self) -> pg.Surface:
         raise NotImplementedError
 
     @property
     def backpack_image(self) -> pg.Surface:
         raise NotImplementedError
+
+    def increment_uses(self, num_uses: int) -> None:
+        assert self.stackable
+        assert hasattr(self.ability, 'num_uses')
+        self.ability.num_uses += num_uses
 
 
 class ShotgunMod(Mod):
@@ -55,6 +64,10 @@ class ShotgunMod(Mod):
 
     @property
     def expended(self) -> bool:
+        return False
+
+    @property
+    def stackable(self) -> bool:
         return False
 
     @property
@@ -81,6 +94,10 @@ class PistolMod(Mod):
         return False
 
     @property
+    def stackable(self) -> bool:
+        return False
+
+    @property
     def equipped_image(self) -> pg.Surface:
         return images.get_image(images.PISTOL_MOD)
 
@@ -101,6 +118,10 @@ class VomitMod(Mod):
 
     @property
     def expended(self) -> bool:
+        return False
+
+    @property
+    def stackable(self) -> bool:
         return False
 
     @property
@@ -128,6 +149,10 @@ class HealthPackMod(Mod):
     @property
     def expended(self) -> bool:
         return self._ability.uses_left <= 0
+
+    @property
+    def stackable(self) -> bool:
+        return True
 
     @property
     def backpack_image(self) -> pg.Surface:

--- a/src/mods.py
+++ b/src/mods.py
@@ -48,8 +48,8 @@ class Mod(object):
 
     def increment_uses(self, num_uses: int) -> None:
         assert self.stackable
-        assert hasattr(self.ability, 'num_uses')
-        self.ability.num_uses += num_uses
+        assert hasattr(self.ability, 'uses_left')
+        self.ability.uses_left += num_uses
 
 
 class ShotgunMod(Mod):

--- a/src/test/test_a_dungeon_controller.py
+++ b/src/test/test_a_dungeon_controller.py
@@ -101,12 +101,12 @@ class DungeonControllerTest(unittest.TestCase):
         player.attempt_pickup(shotgun)  # shotgun mod goes to slot 0 in backpack
 
         player.attempt_pickup(HealthPackObject(pos))
-        health_pack_1 = HealthPackObject(pos)
-        player.attempt_pickup(health_pack_1)
+        shotgun_2 = ShotgunObject(pos)
+        player.attempt_pickup(shotgun_2)
 
-        self.assertIs(player.backpack[1], health_pack_1.mod)
+        self.assertIs(player.backpack[1], shotgun_2.mod)
         player.equip(shotgun.mod)
-        self.assertIs(player.backpack[1], health_pack_1.mod)
+        self.assertIs(player.backpack[1], shotgun_2.mod)
 
 
 if __name__ == '__main__':

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -163,7 +163,7 @@ class ModTest(unittest.TestCase):
         self.assertEqual(arm_mod, pistol.mod)
         self.assertIn(shotgun.mod, backpack)
 
-    def test_mod_stacking_in_active_mods(self):
+    def test_mod_stacking_in_active_mods(self) -> None:
         player = _make_player()
         pos = Vector2(0, 0)
         hp = mods.HealthPackObject(pos)
@@ -183,7 +183,7 @@ class ModTest(unittest.TestCase):
         player_mod = player.active_mods[hp.mod.loc]
         self.assertEqual(player_mod.ability.uses_left, 3)
 
-    def test_mod_stacking_in_backpack(self):
+    def test_mod_stacking_in_backpack(self) -> None:
         player = _make_player()
         pos = Vector2(0, 0)
 

--- a/src/test/test_items.py
+++ b/src/test/test_items.py
@@ -65,7 +65,7 @@ class ModTest(unittest.TestCase):
 
     def test_backpack_full(self) -> None:
         player = _make_player()
-        hp = _make_item(ObjectType.HEALTHPACK)
+        pistol = _make_item(ObjectType.PISTOL)
 
         backpack = player.backpack
         self.assertEqual(len(backpack), player.backpack.size)
@@ -74,11 +74,11 @@ class ModTest(unittest.TestCase):
 
         for i in range(player.backpack.size + 1):
             self.assertFalse(player.backpack.is_full)
-            player.attempt_pickup(hp)
+            player.attempt_pickup(pistol)
         self.assertTrue(player.backpack.is_full)
 
         # Item not gained since backpack full
-        player.attempt_pickup(hp)
+        player.attempt_pickup(pistol)
         self.assertEqual(len(backpack), player.backpack.size)
 
     def test_use_health_pack(self) -> None:
@@ -89,13 +89,14 @@ class ModTest(unittest.TestCase):
 
         player.attempt_pickup(hp)
         # healthpack goes straight to active mods.
-        self.assertNotIn(hp.mod, backpack)
+        self.assertNotIn(hp.mod, backpack)  # healthpack added to stack.
         active_mods = player.active_mods
         self.assertIn(hp.mod, active_mods.values())
 
         hp_2 = _make_item(ObjectType.HEALTHPACK)
         player.attempt_pickup(hp_2)
-        self.assertIn(hp_2.mod, backpack)
+
+        self.assertNotIn(hp_2.mod, backpack)
 
         # health is full
         self.assertFalse(player.damaged)
@@ -117,10 +118,10 @@ class ModTest(unittest.TestCase):
         use_hp_mod = player.ability_caller(hp.mod.loc)
         use_hp_mod()
 
-        self.assertTrue(hp.mod.expended)
+        self.assertFalse(hp.mod.expended)
+        self.assertEqual(hp.mod.ability.uses_left, 1)
         self.assertNotIn(hp.mod, backpack)
         self.assertFalse(player.damaged)
-        self.assertEqual(len(active_mods.values()), 0)
 
         hp = _make_item(ObjectType.HEALTHPACK)
         player.attempt_pickup(hp)
@@ -132,7 +133,6 @@ class ModTest(unittest.TestCase):
 
         # health pack doesn't fill you over max health
         self.assertEqual(player.health, player.max_health)
-        self.assertEqual(len(active_mods.values()), 0)
 
     def test_add_weapons(self) -> None:
         player = _make_player()


### PR DESCRIPTION
Give Mods a boolean stackable property, which requires that their ability property has a uses_left attribute. Mods with stackable==True are stacked in the backpack and active mods. Number of uses left is displayed in the HUD.