### PR TITLE
add a coverage config file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,28 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+sort = Cover
+
+[html]
+directory = coverage_html_report


### PR DESCRIPTION
1) ignore debug statements (we don't use these so far)
2) ignore error asserts
3) ignore all the __main__ statements in tests
4) sort the output from least covered to most