### PR TITLE
Load ProjectileData from .yml file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ networkx==2.0
 pygame==1.9.3
 pytweening>=1.0.3
 pytmx>=3.21.3
-attrs>=17.4.0
+PyYAML>=1.3

--- a/src/creatures/mobs.py
+++ b/src/creatures/mobs.py
@@ -1,5 +1,4 @@
 from random import choice, random
-from typing import List
 
 import pygame as pg
 from pygame.math import Vector2
@@ -9,11 +8,11 @@ import images
 import items.bullet_weapons
 import settings
 import sounds
-from abilities import Ability, ProjectileAbilityData, AbilityFactory
+from abilities import ProjectileAbilityData
 from creatures.humanoids import Humanoid
 from creatures.players import Player
-from mods import Mod, ModLocation, Buffs, Proficiencies, ModData, Mod
-from projectiles import ProjectileData
+from data.input_output import load_projectile_data
+from mods import ModLocation, ModData, Mod
 
 MOB_SPEEDS = [150, 100, 75, 125]
 MOB_HIT_RECT = pg.Rect(0, 0, 30, 30)
@@ -145,10 +144,7 @@ def spew_vomit_effect(origin: Vector2) -> None:
 
 
 def vomit_mod() -> Mod:
-    projectile_data = ProjectileData(hits_player=True, damage=20,
-                                     speed=300,
-                                     max_lifetime=600,
-                                     image_file=images.VOMIT)
+    projectile_data = load_projectile_data('vomit')
     ability_data = ProjectileAbilityData(250,
                                          projectile_data=projectile_data,
                                          projectile_count=1,

--- a/src/creatures/mobs.py
+++ b/src/creatures/mobs.py
@@ -12,7 +12,7 @@ import sounds
 from abilities import Ability, ProjectileAbilityData, AbilityFactory
 from creatures.humanoids import Humanoid
 from creatures.players import Player
-from mods import Mod, ModLocation, Buffs, Proficiencies, ModData, ModFromData
+from mods import Mod, ModLocation, Buffs, Proficiencies, ModData, Mod
 from projectiles import ProjectileData
 
 MOB_SPEEDS = [150, 100, 75, 125]
@@ -157,4 +157,4 @@ def vomit_mod() -> Mod:
 
     mod_data = ModData(ModLocation.HEAD, ability_data,
                        'none', 'none', 'vomit')
-    return ModFromData(mod_data)
+    return Mod(mod_data)

--- a/src/creatures/mobs.py
+++ b/src/creatures/mobs.py
@@ -12,7 +12,7 @@ import sounds
 from abilities import Ability, ProjectileAbilityData, AbilityFactory
 from creatures.humanoids import Humanoid
 from creatures.players import Player
-from mods import Mod, ModLocation, Buffs, Proficiencies
+from mods import Mod, ModLocation, Buffs, Proficiencies, ModData, ModFromData
 from projectiles import ProjectileData
 
 MOB_SPEEDS = [150, 100, 75, 125]
@@ -51,7 +51,7 @@ class Mob(Humanoid):
 
         if self.is_quest:
             self.speed *= 2
-            self._vomit_mod = VomitMod()
+            self._vomit_mod = vomit_mod()
             self.active_mods[self._vomit_mod.loc] = self._vomit_mod
 
     @property
@@ -144,47 +144,17 @@ def spew_vomit_effect(origin: Vector2) -> None:
     sounds.spew_vomit_sound()
 
 
-class VomitMod(Mod):
-    loc = ModLocation.HEAD
+def vomit_mod() -> Mod:
+    projectile_data = ProjectileData(hits_player=True, damage=20,
+                                     speed=300,
+                                     max_lifetime=600,
+                                     image_file=images.VOMIT)
+    ability_data = ProjectileAbilityData(250,
+                                         projectile_data=projectile_data,
+                                         projectile_count=1,
+                                         kickback=0, spread=5,
+                                         fire_effects=[spew_vomit_effect])
 
-    def __init__(self, buffs: List[Buffs] = None,
-                 perks: List[Proficiencies] = None) -> None:
-        super().__init__(buffs, perks)
-
-        projectile_data = ProjectileData(hits_player=True, damage=20,
-                                         speed=300,
-                                         max_lifetime=600,
-                                         image_file=images.VOMIT)
-        ability_data = ProjectileAbilityData(250,
-                                             projectile_data=projectile_data,
-                                             projectile_count=1,
-                                             kickback=0, spread=5,
-                                             fire_effects=[spew_vomit_effect])
-
-        self._ability = AbilityFactory(ability_data).build()
-
-    @property
-    def ability(self) -> Ability:
-        return self._ability
-
-    @property
-    def expended(self) -> bool:
-        return False
-
-    @property
-    def stackable(self) -> bool:
-        return False
-
-    @property
-    def equipped_image(self) -> pg.Surface:
-        raise RuntimeError('This is a zombie ability and should not be '
-                           'visible.')
-
-    @property
-    def backpack_image(self) -> pg.Surface:
-        raise RuntimeError('This is a zombie ability and should not be '
-                           'visible.')
-
-    @property
-    def description(self) -> str:
-        return 'Vomit'
+    mod_data = ModData(ModLocation.HEAD, ability_data,
+                       'none', 'none', 'vomit')
+    return ModFromData(mod_data)

--- a/src/data/input_output.py
+++ b/src/data/input_output.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+import yaml
+
+from projectiles import ProjectileData
+
+from src import __path__ as _src_path
+
+_src_path = _src_path[0]
+
+PROJECTILE_FILE = _src_path + "/data/projectiles.yml"
+
+
+def print_rock_err_msg(*args: Any):
+    print('Missing RockObject')
+
+
+def load_projectile_data(name: str) -> ProjectileData:
+    with open(PROJECTILE_FILE, 'r') as stream:
+        try:
+            data = yaml.load(stream)
+            kwargs = data[name]
+            if 'drops_on_kill' in kwargs:
+                assert kwargs['drops_on_kill'] == 'RockObject'
+                kwargs['drops_on_kill'] = print_rock_err_msg
+            return ProjectileData(**kwargs)
+        except yaml.YAMLError as exc:
+            print(exc)

--- a/src/data/input_output.py
+++ b/src/data/input_output.py
@@ -4,14 +4,14 @@ import yaml
 
 from projectiles import ProjectileData
 
-from src import __path__ as _src_path
+from src import __path__ as _src_path  # type: ignore
 
 _src_path = _src_path[0]
 
 PROJECTILE_FILE = _src_path + "/data/projectiles.yml"
 
 
-def print_rock_err_msg(*args: Any):
+def print_rock_err_msg(*args: Any) -> None:
     print('Missing RockObject')
 
 

--- a/src/data/projectiles.yml
+++ b/src/data/projectiles.yml
@@ -1,0 +1,33 @@
+bullet:
+  hits_player: false
+  damage: 75
+  speed: 1000
+  max_lifetime: 400
+  image_file: "bullet.png"
+little_bullet:
+  hits_player: false
+  damage: 25
+  speed: 500
+  max_lifetime: 500
+  image_file: "little_bullet.png"
+vomit:
+  hits_player: true
+  damage: 20
+  speed: 300
+  max_lifetime: 600
+  image_file: "vomit.png"
+laser:
+  hits_player: false
+  damage: 100
+  speed: 1000
+  max_lifetime: 1000
+  image_file: "little_laser.png"
+  angled_image: true
+rock:
+  hits_player: false
+  damage: 25
+  speed: 250
+  max_lifetime: 800
+  image_file: "little_rock.png"
+  rotating_image: true
+  drops_on_kill: RockObject

--- a/src/items/bullet_weapons.py
+++ b/src/items/bullet_weapons.py
@@ -8,7 +8,7 @@ import settings
 import sounds
 from abilities import ProjectileAbilityData
 from model import DynamicObject
-from mods import ModLocation, ItemObject, ModData, ModFromData
+from mods import ModLocation, ItemObject, ModData, Mod
 from tilemap import ObjectType
 from projectiles import ProjectileData
 
@@ -63,7 +63,7 @@ class PistolObject(ItemObject):
         mod_data = ModData(ModLocation.ARMS, ability_data, images.PISTOL_MOD,
                            images.PISTOL, 'pistol')
 
-        mod = ModFromData(mod_data)
+        mod = Mod(mod_data)
 
         super().__init__(mod, pos)
 
@@ -93,7 +93,7 @@ class ShotgunObject(ItemObject):
         mod_data = ModData(ModLocation.ARMS, ability_data, images.SHOTGUN_MOD,
                            images.SHOTGUN, 'shotgun')
 
-        mod = ModFromData(mod_data)
+        mod = Mod(mod_data)
 
         super().__init__(mod, pos)
 

--- a/src/items/bullet_weapons.py
+++ b/src/items/bullet_weapons.py
@@ -7,10 +7,10 @@ import images
 import settings
 import sounds
 from abilities import ProjectileAbilityData
+from data.input_output import load_projectile_data
 from model import DynamicObject
 from mods import ModLocation, ItemObject, ModData, Mod
 from tilemap import ObjectType
-from projectiles import ProjectileData
 
 
 class MuzzleFlash(DynamicObject):
@@ -49,10 +49,8 @@ class PistolObject(ItemObject):
     def __init__(self, pos: Vector2) -> None:
         self._check_class_initialized()
 
-        projectile_data = ProjectileData(hits_player=False, damage=75,
-                                         speed=1000,
-                                         max_lifetime=400,
-                                         image_file=images.BULLET_IMG)
+        projectile_data = load_projectile_data('bullet')
+
         ability_data = ProjectileAbilityData(250,
                                              projectile_data=projectile_data,
                                              projectile_count=1,
@@ -80,10 +78,7 @@ class ShotgunObject(ItemObject):
     def __init__(self, pos: Vector2) -> None:
         self._check_class_initialized()
 
-        projectile_data = ProjectileData(hits_player=False, damage=25,
-                                         speed=500,
-                                         max_lifetime=500,
-                                         image_file=images.LITTLE_BULLET)
+        projectile_data = load_projectile_data('little_bullet')
         ability_data = ProjectileAbilityData(900,
                                              projectile_data=projectile_data,
                                              projectile_count=12,

--- a/src/items/laser_weapons.py
+++ b/src/items/laser_weapons.py
@@ -4,9 +4,9 @@ from pygame.surface import Surface
 import images
 import sounds
 from abilities import ProjectileAbilityData
+from data.input_output import load_projectile_data
 from mods import ModLocation, ItemObject, ModData, Mod
 from tilemap import ObjectType
-from projectiles import ProjectileData
 
 
 def laser_pew_sound(origin: Vector2) -> None:
@@ -19,11 +19,7 @@ class LaserGun(ItemObject):
     def __init__(self, pos: Vector2) -> None:
         self._check_class_initialized()
 
-        projectile_data = ProjectileData(hits_player=False, damage=100,
-                                         speed=1000,
-                                         max_lifetime=1000,
-                                         image_file=images.LITTLE_LASER,
-                                         angled_image=True)
+        projectile_data = load_projectile_data('laser')
         ability_data = ProjectileAbilityData(500,
                                              projectile_data=projectile_data,
                                              projectile_count=1,

--- a/src/items/laser_weapons.py
+++ b/src/items/laser_weapons.py
@@ -1,4 +1,3 @@
-
 from pygame.math import Vector2
 from pygame.surface import Surface
 

--- a/src/items/laser_weapons.py
+++ b/src/items/laser_weapons.py
@@ -4,7 +4,7 @@ from pygame.surface import Surface
 import images
 import sounds
 from abilities import ProjectileAbilityData
-from mods import ModLocation, ItemObject, ModData, ModFromData
+from mods import ModLocation, ItemObject, ModData, Mod
 from tilemap import ObjectType
 from projectiles import ProjectileData
 
@@ -33,7 +33,7 @@ class LaserGun(ItemObject):
 
         mod_data = ModData(ModLocation.ARMS, ability_data,
                            images.LASER_BOLT, images.LASER_GUN, 'laser gun')
-        mod = ModFromData(mod_data)
+        mod = Mod(mod_data)
 
         super().__init__(mod, pos)
 

--- a/src/items/rocks.py
+++ b/src/items/rocks.py
@@ -5,7 +5,7 @@ from pygame.math import Vector2
 
 from abilities import ProjectileAbilityData
 import images
-from mods import ItemObject, ModLocation, ModData, ModFromData
+from mods import ItemObject, ModLocation, ModData, Mod
 from sounds import fire_weapon_sound
 from tilemap import ObjectType
 from projectiles import ProjectileData
@@ -31,7 +31,7 @@ class RockObject(ItemObject):
         mod_data = ModData(ModLocation.ARMS, ability_data, images.ROCK,
                            images.ROCK, 'Rock', True)
 
-        mod = ModFromData(mod_data)
+        mod = Mod(mod_data)
 
         super().__init__(mod, pos)
 

--- a/src/items/rocks.py
+++ b/src/items/rocks.py
@@ -5,10 +5,10 @@ from pygame.math import Vector2
 
 from abilities import ProjectileAbilityData
 import images
+from data.input_output import load_projectile_data
 from mods import ItemObject, ModLocation, ModData, Mod
 from sounds import fire_weapon_sound
 from tilemap import ObjectType
-from projectiles import ProjectileData
 
 
 class RockObject(ItemObject):
@@ -17,12 +17,7 @@ class RockObject(ItemObject):
     def __init__(self, pos: Vector2) -> None:
         self._check_class_initialized()
 
-        projectile_data = ProjectileData(hits_player=False, damage=25,
-                                         speed=250,
-                                         max_lifetime=800,
-                                         image_file=images.LITTLE_ROCK,
-                                         rotating_image=True,
-                                         drops_on_kill=RockObject)
+        projectile_data = load_projectile_data('rock')
         ability_data = ProjectileAbilityData(500,
                                              projectile_data=projectile_data,
                                              spread=2,

--- a/src/items/utility_items.py
+++ b/src/items/utility_items.py
@@ -3,7 +3,7 @@ from pygame.math import Vector2
 
 import images
 from abilities import RegenerationAbilityData
-from mods import ModLocation, ItemObject, ModData, ModFromData
+from mods import ModLocation, ItemObject, ModData, Mod
 
 BATTERY_AMOUNT = 50
 HEALTH_PACK_AMOUNT = 20
@@ -20,7 +20,7 @@ class HealthPackObject(ItemObject):
         mod_data = ModData(ModLocation.CHEST, ability_data, images.HEALTH_PACK,
                            images.HEALTH_PACK, 'healthpack', True)
 
-        mod = ModFromData(mod_data)
+        mod = Mod(mod_data)
 
         super().__init__(mod, pos)
 
@@ -39,7 +39,7 @@ class Battery(ItemObject):
         mod_data = ModData(ModLocation.CHEST, ability_data, images.LIGHTNING,
                            images.ENERGY_PACK, 'battery', True)
 
-        mod = ModFromData(mod_data)
+        mod = Mod(mod_data)
 
         super().__init__(mod, pos)
 

--- a/src/mods.py
+++ b/src/mods.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from enum import Enum
-from typing import List, Set
+from typing import List, Set, Any
 
 import pygame as pg
 import pytweening as tween
@@ -37,55 +37,6 @@ class Proficiencies(Enum):
     ATHLETICISM = 'athleticism'
 
 
-class Mod(object):
-    def __init__(self, buffs: List[Buffs] = None,
-                 profs: List[Proficiencies] = None) -> None:
-        buffs = [] if buffs is None else buffs
-        profs = [] if profs is None else profs
-
-        self._buffs = list(buffs)
-        self._profs = list(profs)
-
-    @property
-    def loc(self) -> ModLocation:
-        raise NotImplementedError
-
-    @property
-    def expended(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def ability(self) -> Ability:
-        raise NotImplementedError
-
-    @property
-    def stackable(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def equipped_image(self) -> pg.Surface:
-        raise NotImplementedError
-
-    @property
-    def backpack_image(self) -> pg.Surface:
-        raise NotImplementedError
-
-    @property
-    def description(self) -> str:
-        raise NotImplementedError
-
-    def __str__(self) -> str:
-        output = '%s' % (self.description)
-        if self._buffs or self._profs:
-            output += '('
-            for buff in self._buffs:
-                output += '%s, ' % (buff.value,)
-            for prof in self._profs:
-                output += '%s, ' % (prof.value,)
-            output += ')'
-        return output
-
-
 BaseModData = namedtuple('BaseModData',
                          ('location', 'ability_data', 'equipped_image',
                           'backpack_image', 'description', 'stackable',
@@ -104,7 +55,7 @@ class ModData(BaseModData):
                                proficiencies)
 
 
-class ModFromData(Mod):
+class Mod(object):
     def __init__(self, data: ModData) -> None:
         self._data = data
         self._buffs = data.buffs
@@ -146,10 +97,21 @@ class ModFromData(Mod):
     def stackable(self) -> bool:
         return self._data.stackable
 
-    def __eq__(self, other: Mod) -> bool:  # type: ignore
+    def __eq__(self, other: Any) -> bool:  # type: ignore
         if not isinstance(other, type(self)):
             return False
         return self._data == other._data
+
+    def __str__(self) -> str:
+        output = '%s' % (self.description)
+        if self._buffs or self._profs:
+            output += '('
+            for buff in self._buffs:
+                output += '%s, ' % (buff.value,)
+            for prof in self._profs:
+                output += '%s, ' % (prof.value,)
+            output += ')'
+        return output
 
 
 class ItemObject(DynamicObject):

--- a/src/mods.py
+++ b/src/mods.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from enum import Enum
-from typing import List, Set, Any
+from typing import Set, Any
 
 import pygame as pg
 import pytweening as tween

--- a/src/projectiles.py
+++ b/src/projectiles.py
@@ -1,6 +1,5 @@
 from collections import Callable, namedtuple
 from random import uniform
-from typing import Any
 
 import pygame as pg
 from pygame.math import Vector2

--- a/src/projectiles.py
+++ b/src/projectiles.py
@@ -1,5 +1,6 @@
 from collections import Callable, namedtuple
 from random import uniform
+from typing import Any
 
 import pygame as pg
 from pygame.math import Vector2

--- a/src/test/test_humanoid.py
+++ b/src/test/test_humanoid.py
@@ -3,16 +3,19 @@ from typing import Tuple
 from pygame.math import Vector2
 from pygame.sprite import Group, LayeredUpdates
 import model
+from items.rocks import RockObject
 from src.test.pygame_mock import MockTimer, initialize_pygame, \
     initialize_gameobjects
 from itertools import product
 import math
 from src.test.testing_utilities import make_player, make_mob
+from test import dummy_audio_video
 
 
 def setUpModule() -> None:
     initialize_pygame()
     initialize_gameobjects(HumanoidsTest.groups, HumanoidsTest.timer)
+    dummy_audio_video
 
 
 def _dist(pos_0: Vector2, pos_1: Vector2) -> float:
@@ -189,6 +192,17 @@ class HumanoidsTest(unittest.TestCase):
 
         mob.update()
         self.assertNotIn(mob, groups.mobs)
+
+    def test_pickup_rock_adds_to_active_mods(self):
+        player = make_player()
+
+        player.attempt_pickup(RockObject(player.pos))
+
+        self.assertFalse(player.backpack.slot_occupied(0))
+
+        player.attempt_pickup(RockObject(player.pos))
+        self.assertFalse(player.backpack.slot_occupied(0))
+
 
 
 if __name__ == '__main__':

--- a/src/test/test_humanoid.py
+++ b/src/test/test_humanoid.py
@@ -193,7 +193,7 @@ class HumanoidsTest(unittest.TestCase):
         mob.update()
         self.assertNotIn(mob, groups.mobs)
 
-    def test_pickup_rock_adds_to_active_mods(self):
+    def test_pickup_rock_adds_to_active_mods(self) -> None:
         player = make_player()
 
         player.attempt_pickup(RockObject(player.pos))
@@ -202,7 +202,6 @@ class HumanoidsTest(unittest.TestCase):
 
         player.attempt_pickup(RockObject(player.pos))
         self.assertFalse(player.backpack.slot_occupied(0))
-
 
 
 if __name__ == '__main__':

--- a/src/test/test_input_output.py
+++ b/src/test/test_input_output.py
@@ -1,0 +1,13 @@
+import unittest
+
+from data.input_output import load_projectile_data
+from projectiles import ProjectileData
+
+
+class InputOutputTest(unittest.TestCase):
+    def test_load_projectile_data(self):
+        data = load_projectile_data('bullet')
+
+        expected_data = ProjectileData(False, 75, 1000, 400, "bullet.png")
+
+        self.assertEqual(data, expected_data)

--- a/src/test/test_input_output.py
+++ b/src/test/test_input_output.py
@@ -5,7 +5,7 @@ from projectiles import ProjectileData
 
 
 class InputOutputTest(unittest.TestCase):
-    def test_load_projectile_data(self):
+    def test_load_projectile_data(self) -> None:
         data = load_projectile_data('bullet')
 
         expected_data = ProjectileData(False, 75, 1000, 400, "bullet.png")

--- a/src/test/test_mods.py
+++ b/src/test/test_mods.py
@@ -2,7 +2,7 @@ import unittest
 from pygame.math import Vector2
 import model
 from abilities import AbilityData, RegenerationAbilityData, RegenerationAbility
-from mods import Mod, Proficiencies, Buffs, ModData, ModLocation, ModFromData
+from mods import Mod, Proficiencies, Buffs, ModData, ModLocation
 from items.bullet_weapons import PistolObject
 from src.test.pygame_mock import MockTimer, initialize_pygame, \
     initialize_gameobjects
@@ -27,20 +27,6 @@ class ModTest(unittest.TestCase):
         self.groups.empty()
         self.timer.reset()
 
-    def test_mod_base_class_abstract_properties(self) -> None:
-        mod_base = Mod()
-        with self.assertRaises(NotImplementedError):
-            mod_base.loc
-
-        with self.assertRaises(NotImplementedError):
-            mod_base.expended
-
-        with self.assertRaises(NotImplementedError):
-            mod_base.equipped_image
-
-        with self.assertRaises(NotImplementedError):
-            mod_base.backpack_image
-
     def test_item_object_bob_motion(self) -> None:
         pistol_item = PistolObject(Vector2(0, 0))
         time_for_sweep = int(pistol_item._bob_period * 10)
@@ -63,7 +49,7 @@ class ModTest(unittest.TestCase):
         description = 'banana hammock'
         mod_data = ModData(ModLocation.LEGS, self.ability_data,
                            'no_image', 'no_image', description)
-        hammock_mod = ModFromData(mod_data)
+        hammock_mod = Mod(mod_data)
 
         self.assertEqual(hammock_mod.description, description)
         self.assertEqual(str(hammock_mod), description)
@@ -72,7 +58,7 @@ class ModTest(unittest.TestCase):
                            'no_image', 'no_image', description,
                            buffs=[Buffs.DAMAGE],
                            proficiencies=[Proficiencies.STEALTH])
-        nice_mod = ModFromData(mod_data)
+        nice_mod = Mod(mod_data)
 
         self.assertIn('damage', str(nice_mod))
         self.assertIn('stealth', str(nice_mod))

--- a/src/test/test_projectiles.py
+++ b/src/test/test_projectiles.py
@@ -4,6 +4,7 @@ from pygame.math import Vector2
 
 import images
 import model
+from data.input_output import load_projectile_data
 from projectiles import ProjectileData, SimpleProjectile, ProjectileFactory, \
     FancyProjectile
 from test.pygame_mock import initialize_pygame, initialize_gameobjects, \
@@ -113,3 +114,8 @@ class ProjectilesTest(unittest.TestCase):
             self.assertEqual(len(self.groups.all_sprites), k + 1)
             self.assertEqual(len(self.groups.enemy_projectiles), k + 1)
             self.assertEqual(len(self.groups.bullets), 0)
+
+    def test_projectile_data_eq(self):
+        rock_data_0 = load_projectile_data('rock')
+        rock_data_1 = load_projectile_data('rock')
+        self.assertEqual(rock_data_0, rock_data_1)

--- a/src/test/test_projectiles.py
+++ b/src/test/test_projectiles.py
@@ -115,7 +115,7 @@ class ProjectilesTest(unittest.TestCase):
             self.assertEqual(len(self.groups.enemy_projectiles), k + 1)
             self.assertEqual(len(self.groups.bullets), 0)
 
-    def test_projectile_data_eq(self):
+    def test_projectile_data_eq(self) -> None:
         rock_data_0 = load_projectile_data('rock')
         rock_data_1 = load_projectile_data('rock')
         self.assertEqual(rock_data_0, rock_data_1)


### PR DESCRIPTION
Setup the data package, where GameObject data will be stored. Set up input_output.py to implement reading of .yml files that encode ProjectileData. All projectiles are now defined using this data alone. Also all Mods are loaded from data now, so I got rid of the Mod base class and replaced it with ModFromData (renamed Mod).