### PR TITLE
Add back teleport ability

### DIFF
--- a/src/abilities.py
+++ b/src/abilities.py
@@ -82,7 +82,7 @@ class GenericAbility(Ability):
     def __init__(self, data: AbilityData) -> None:
         super().__init__()
 
-        cool_down = CooldownCondition(self.timer, data.cool_down_time)
+        cool_down = CooldownCondition(data.cool_down_time)
         update_use = UpdateLastUse(cool_down)
         self.add_use_condition(cool_down)
         self.add_use_effect(update_use)

--- a/src/controllers/dungeon_controller.py
+++ b/src/controllers/dungeon_controller.py
@@ -130,6 +130,8 @@ class DungeonController(controllers.base.Controller):
 
     def draw(self) -> None:
 
+        self._view.draw_teleport_text = any(
+            res.can_resolve for res in self._teleport_resolutions)
         self._view.draw(self._dungeon.player, self._dungeon.map)
 
         pg.display.flip()

--- a/src/controllers/dungeon_controller.py
+++ b/src/controllers/dungeon_controller.py
@@ -18,6 +18,7 @@ from data import constructors
 from items import ItemObject
 
 from projectiles import Projectile
+from quests.resolutions import Resolution, RequiresTeleport
 
 
 class Dungeon(model.GroupsAccess):
@@ -108,7 +109,8 @@ class DungeonController(controllers.base.Controller):
      user.
      """
 
-    def __init__(self, dungeon: Dungeon) -> None:
+    def __init__(self, dungeon: Dungeon,
+                 resolutions: List[Resolution]) -> None:
         super().__init__()
 
         self._dungeon = dungeon
@@ -116,6 +118,10 @@ class DungeonController(controllers.base.Controller):
         self._view = view.DungeonView(self._screen)
         self._view.set_camera_range(self._dungeon.map.width,
                                     self._dungeon.map.height)
+
+        self._teleport_resolutions: List[RequiresTeleport, ...] = None
+        self._teleport_resolutions = [res for res in resolutions if
+                                      isinstance(res, RequiresTeleport)]
 
         self._init_controls(self._dungeon.player)
 
@@ -177,7 +183,7 @@ class DungeonController(controllers.base.Controller):
         # equip / use
         self.keyboard.bind_on_press(pg.K_e, self._try_equip)
 
-        # self.keyboard.bind_on_press(pg.K_t, self._teleport)
+        self.keyboard.bind_on_press(pg.K_t, self._teleport)
 
     def _handle_hud(self) -> None:
         self._view.try_click_hud(self.keyboard.mouse_pos)
@@ -229,5 +235,6 @@ class DungeonController(controllers.base.Controller):
         self._dungeon.groups.empty()
         del self
 
-        # def _teleport(self) -> None:
-        #     self._teleported = True
+    def _teleport(self) -> None:
+        for res in self._teleport_resolutions:
+            res.toggle_teleport()

--- a/src/controllers/dungeon_controller.py
+++ b/src/controllers/dungeon_controller.py
@@ -119,7 +119,7 @@ class DungeonController(controllers.base.Controller):
         self._view.set_camera_range(self._dungeon.map.width,
                                     self._dungeon.map.height)
 
-        self._teleport_resolutions: List[RequiresTeleport, ...] = None
+        self._teleport_resolutions: List[RequiresTeleport] = None
         self._teleport_resolutions = [res for res in resolutions if
                                       isinstance(res, RequiresTeleport)]
 

--- a/src/creatures/enemies.py
+++ b/src/creatures/enemies.py
@@ -117,8 +117,7 @@ class Behavior(object):
                 if effect_data is not None and 'conditions' in effect_data:
                     condition = None
                     for cond_data in effect_data['conditions']:
-                        new_cond = condition_from_data(cond_data, player,
-                                                       timer)
+                        new_cond = condition_from_data(cond_data, player)
                         if condition is None:
                             condition = new_cond
                         else:
@@ -143,7 +142,7 @@ class Behavior(object):
             else:
                 condition_values = {}
                 for cond_data in conditions_list:
-                    condition = condition_from_data(cond_data, player, timer)
+                    condition = condition_from_data(cond_data, player)
                     value = self._condition_value_from_data(cond_data)
                     condition_values[condition] = value
                 self._state_conditions_values[state] = condition_values

--- a/src/data/quests/zombie_quest.yml
+++ b/src/data/quests/zombie_quest.yml
@@ -61,6 +61,10 @@ near zombie: &near_zombie
     - enter zone:
         <<: *player_exits
         next scene: game over win
+    - kill group: &kill_all_quest
+        group label: quest
+        requires teleport:
+        next scene: game over win
     - condition: *player_death
 
 avoid zombie:

--- a/src/data/quests/zombie_quest.yml
+++ b/src/data/quests/zombie_quest.yml
@@ -15,6 +15,7 @@ start cave:
         zone label: 'exit'
         entering label: 'player'
         next scene: first encounter
+        requires teleport:
     - condition: &player_death
         tested label: 'player'
         condition data:

--- a/src/maps/zombie_quest/far_zombie.tmx
+++ b/src/maps/zombie_quest/far_zombie.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="15" height="13" tilewidth="64" tileheight="64" nextobjectid="8">
+<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="15" height="13" tilewidth="64" tileheight="64" nextobjectid="9">
  <tileset firstgid="1" source="red rocks.tsx"/>
  <tileset firstgid="257" source="grey rocks.tsx"/>
  <layer name="Tile Layer 1" width="15" height="13">
@@ -40,5 +40,6 @@
     <property name="labels" value="exit"/>
    </properties>
   </object>
+  <object id="8" name="wall" x="321" y="-66" width="320" height="64"/>
  </objectgroup>
 </map>

--- a/src/maps/zombie_quest/near_zombie.tmx
+++ b/src/maps/zombie_quest/near_zombie.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="15" height="13" tilewidth="64" tileheight="64" nextobjectid="8">
+<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="15" height="13" tilewidth="64" tileheight="64" nextobjectid="9">
  <tileset firstgid="1" source="red rocks.tsx"/>
  <tileset firstgid="257" source="grey rocks.tsx"/>
  <layer name="Tile Layer 1" width="15" height="13">
@@ -23,6 +23,7 @@
   <object id="1" name="wall" x="256" y="0" width="64" height="703"/>
   <object id="2" name="wall" x="640" y="0" width="64" height="703"/>
   <object id="3" name="wall" x="322" y="639.5" width="320" height="64"/>
+  <object id="8" name="wall" x="321" y="-65" width="320" height="64"/>
  </objectgroup>
  <objectgroup name="gameObjects">
   <object id="5" name="red_zombie" x="462" y="256" width="32" height="32">

--- a/src/maps/zombie_quest/root.tmx
+++ b/src/maps/zombie_quest/root.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="20" height="12" tilewidth="64" tileheight="64" nextobjectid="11">
+<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="20" height="12" tilewidth="64" tileheight="64" nextobjectid="12">
  <tileset firstgid="1" source="red rocks.tsx"/>
  <tileset firstgid="257" source="grey rocks.tsx"/>
  <layer name="Tile Layer 1" width="20" height="12">
@@ -21,7 +21,8 @@
  <objectgroup name="walls">
   <object id="1" name="wall" x="384" y="0" width="64" height="639"/>
   <object id="2" name="wall" x="768" y="0" width="64" height="639"/>
-  <object id="3" name="wall" x="450" y="575.5" width="320" height="64"/>
+  <object id="3" name="wall" x="448" y="-63.5" width="320" height="64"/>
+  <object id="11" name="wall" x="364" y="558" width="320" height="64"/>
  </objectgroup>
  <objectgroup name="gameObjects">
   <object id="6" name="player" x="589" y="478" width="32" height="32">

--- a/src/quests/quest.py
+++ b/src/quests/quest.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Dict, Union, Sequence
 
 import networkx
@@ -120,8 +121,8 @@ class Quest(object):
                     res.is_resolved]
 
         if len(resolved) not in (0, 1):
-            raise Warning('More than one resolved resolutions: {}. '
-                          'Choosing first in list.'.format(resolved))
+            warnings.warn('More than one resolved resolutions: {}. Choosing '
+                          'first in list.'.format(resolved))
 
         if resolved:
             return resolved[0]

--- a/src/quests/resolutions.py
+++ b/src/quests/resolutions.py
@@ -28,7 +28,7 @@ class ResolutionModifiers(Enum):
     REQUIRES_TELEPORT = 'requires teleport'
 
     @classmethod
-    def has_value(cls, value) -> bool:
+    def has_value(cls, value: Any) -> bool:
         return any(value == item.value for item in cls)
 
 

--- a/src/quests/resolutions.py
+++ b/src/quests/resolutions.py
@@ -62,7 +62,11 @@ class RequiresTeleport(Resolution):
         # instant that teleport_on is set to True.
         teleport_on = self._teleport_on
         self._teleport_on = False
-        return self._base_resolution.is_resolved and teleport_on
+        return self.can_resolve and teleport_on
+
+    @property
+    def can_resolve(self) -> bool:
+        return self._base_resolution.is_resolved
 
     def load_sprite_data(self, sprite_categories: SpriteLabels) -> None:
         self._base_resolution.load_sprite_data(sprite_categories)

--- a/src/quests/resolutions.py
+++ b/src/quests/resolutions.py
@@ -1,7 +1,7 @@
 """Possible resolutions to dramatic questions."""
 import abc
 from enum import Enum
-from typing import Dict, Any, Collection
+from typing import Dict, Any, Collection, List, Callable
 
 from pygame.sprite import Group, Sprite, spritecollide
 
@@ -15,11 +15,22 @@ class ResolutionType(Enum):
     CONDITION = 'condition'
     DECISION_CHOICE = 'decision choice'
 
+    @property
+    def arg_labels(self) -> List[str]:
+        return _resolution_args[self]
+
+    @property
+    def constructor(self) -> Callable[Any, Resolution]:
+        return _resolution_map[self]
+
 
 SpriteLabels = Dict[str, Collection[Sprite]]
 
 
 class Resolution(abc.ABC):
+    """Represents a resolution to a Scene, which signals a change to the next.
+    """
+
     @property
     def is_resolved(self) -> bool:
         raise NotImplementedError
@@ -29,12 +40,14 @@ class Resolution(abc.ABC):
         """Called after sprites have been created and categorized from map."""
 
 
-def add_sprites_of_label(label: str, res_data: SpriteLabels,
-                         group: Group) -> None:
+def _add_sprites_of_label(label: str, res_data: SpriteLabels,
+                          group: Group) -> None:
     group.add(*res_data[label])
 
 
 class KillGroup(Resolution):
+    """Resolves when a group is killed."""
+
     def __init__(self, group_label: str) -> None:
         self._group_label = group_label
         self._group_to_kill = Group()
@@ -44,11 +57,13 @@ class KillGroup(Resolution):
         return len(self._group_to_kill) == 0
 
     def load_sprite_data(self, sprite_categories: SpriteLabels) -> None:
-        add_sprites_of_label(self._group_label, sprite_categories,
-                             self._group_to_kill)
+        _add_sprites_of_label(self._group_label, sprite_categories,
+                              self._group_to_kill)
 
 
 class EnterZone(Resolution):
+    """Resolves when a labeled sprite enters a labeled zone."""
+
     def __init__(self, zone_label: str, entering_label: str) -> None:
         self._zone_label = zone_label
         self._entering_label = entering_label
@@ -61,16 +76,19 @@ class EnterZone(Resolution):
                    sprite in self._entering_group)
 
     def load_sprite_data(self, sprite_categories: SpriteLabels) -> None:
-        add_sprites_of_label(self._zone_label, sprite_categories,
-                             self._zone_group)
-        add_sprites_of_label(self._entering_label, sprite_categories,
-                             self._entering_group)
+        _add_sprites_of_label(self._zone_label, sprite_categories,
+                              self._zone_group)
+        _add_sprites_of_label(self._entering_label, sprite_categories,
+                              self._entering_group)
 
 
 class ConditionSatisfied(Resolution):
-    def __init__(self, tested_label: str, condition: Condition) -> None:
+    """Resolves when a Condition is satisfied on a given sprite."""
+
+    def __init__(self, tested_label: str,
+                 condition_data: Dict[str, Any]) -> None:
         self._label = tested_label
-        self._condition = condition
+        self._condition = condition_from_data(condition_data, None, None)
         self._tested: GameObject = None
 
     def load_sprite_data(self, sprite_categories: SpriteLabels) -> None:
@@ -87,6 +105,8 @@ class ConditionSatisfied(Resolution):
 
 
 class MakeDecision(Resolution):
+    """Resolves when the player chooses the described option."""
+
     def __init__(self, description: str) -> None:
         self.description = description
         self._decision_chosen = False
@@ -105,27 +125,26 @@ class MakeDecision(Resolution):
         return 'MakeDecision: {}'.format(self.description)
 
 
+_resolution_args = {ResolutionType.DECISION_CHOICE: ['description'],
+                    ResolutionType.CONDITION:
+                        ['tested label', 'condition data'],
+                    ResolutionType.ENTER_ZONE:
+                        ['zone label', 'entering label'],
+                    ResolutionType.KILL_GROUP: ['group label']}
+
+_resolution_map = {ResolutionType.DECISION_CHOICE: MakeDecision,
+                   ResolutionType.CONDITION: ConditionSatisfied,
+                   ResolutionType.ENTER_ZONE: EnterZone,
+                   ResolutionType.KILL_GROUP: KillGroup}
+
+
 def resolution_from_data(res_data: Dict[str, Any]) -> Resolution:
+    """Constructs a Resolution from a data dictionary."""
     assert len(res_data.keys()) == 1, 'root keys must be the length one, ' \
                                       'matching the resolution label.'
     res_label = list(res_data.keys())[0]
     data = res_data[res_label]
     res_type = ResolutionType(res_label)
 
-    if res_type == ResolutionType.KILL_GROUP:
-        group_label = data['group label']
-        return KillGroup(group_label)
-    elif res_type == ResolutionType.ENTER_ZONE:
-        zone_label = data['zone label']
-        entering_label = data['entering label']
-        return EnterZone(zone_label, entering_label)
-    elif res_type == ResolutionType.CONDITION:
-        condition_data = data['condition data']
-        condition = condition_from_data(condition_data, None, None)
-        tested_label = data['tested label']
-        return ConditionSatisfied(tested_label, condition)
-    elif res_type == ResolutionType.DECISION_CHOICE:
-        return MakeDecision(data['description'])
-    else:
-        raise NotImplementedError('Definition of resolution type {} not yet '
-                                  'implemented'.format(res_type))
+    args = [data[key] for key in res_type.arg_labels]
+    return res_type.constructor(*args)

--- a/src/quests/resolutions.py
+++ b/src/quests/resolutions.py
@@ -5,7 +5,7 @@ from typing import Dict, Any, Collection, List, Callable
 
 from pygame.sprite import Group, Sprite, spritecollide
 
-from conditions import Condition, condition_from_data
+from conditions import condition_from_data
 from model import GameObject
 
 
@@ -119,7 +119,7 @@ class ConditionSatisfied(Resolution):
     def __init__(self, tested_label: str,
                  condition_data: Dict[str, Any]) -> None:
         self._label = tested_label
-        self._condition = condition_from_data(condition_data, None, None)
+        self._condition = condition_from_data(condition_data, None)
         self._tested: GameObject = None
 
     def load_sprite_data(self, sprite_categories: SpriteLabels) -> None:

--- a/src/quests/scenes/dungeons.py
+++ b/src/quests/scenes/dungeons.py
@@ -21,4 +21,5 @@ class DungeonScene(Scene):
         for resolution in resolutions:
             resolution.load_sprite_data(sprite_labels)
 
-        return DungeonController(dungeon), resolutions
+        ctrl = DungeonController(dungeon, resolutions)
+        return ctrl, resolutions

--- a/src/test/test_a_initializations.py
+++ b/src/test/test_a_initializations.py
@@ -5,7 +5,6 @@ import pygame
 
 import creatures.enemies
 import model
-from abilities import Ability
 from src.test.pygame_mock import MockTimer, initialize_pygame
 from src.test.testing_utilities import make_player, make_zombie
 

--- a/src/test/testing_utilities.py
+++ b/src/test/testing_utilities.py
@@ -36,4 +36,4 @@ def make_dungeon_controller() -> DungeonController:
 
     dungeon = Dungeon('test_level.tmx')
 
-    return DungeonController(dungeon)
+    return DungeonController(dungeon, [])

--- a/src/view.py
+++ b/src/view.py
@@ -52,6 +52,7 @@ class DungeonView(model.GroupsAccess):
 
         self._draw_debug = False
         self._night = False
+        self.draw_teleport_text = False
 
         self._fog = pg.Surface((settings.WIDTH, settings.HEIGHT))
         self._fog.fill(settings.NIGHT_COLOR)
@@ -81,6 +82,9 @@ class DungeonView(model.GroupsAccess):
         if self._night:
             self.render_fog(player)
 
+        if self.draw_teleport_text:
+            self._draw_teleport_text()
+
         # draw hud on top of everything
         self._hud.draw(player)
 
@@ -94,6 +98,12 @@ class DungeonView(model.GroupsAccess):
 
         if self._rect_on_screen(rect):
             self._screen.blit(image, rect)
+
+    def _draw_teleport_text(self) -> None:
+
+        font = images.get_font(images.ZOMBIE_FONT)
+        draw_utils.draw_text(self._screen, 'Press T to continue', font,
+                             16, settings.GREEN, 16, 8)
 
     def _rect_on_screen(self, rect: Rect) -> bool:
         return self._screen.get_rect().colliderect(rect)


### PR DESCRIPTION
Resolutions can now be modified with the 'teleport required' label. When they would resolve (in a Dungeon), instead text shows up saying `press T to continue'. Pressing T then resolves the Resolution.